### PR TITLE
8258147: Modernize Nashorn code

### DIFF
--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/api/scripting/NashornException.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/api/scripting/NashornException.java
@@ -81,7 +81,7 @@ public abstract class NashornException extends RuntimeException {
      * @param column    column number
      */
     protected NashornException(final String msg, final Throwable cause, final String fileName, final int line, final int column) {
-        super(msg, cause == null ? null : cause);
+        super(msg, cause);
         this.fileName = fileName;
         this.line = line;
         this.column = column;
@@ -94,7 +94,7 @@ public abstract class NashornException extends RuntimeException {
      * @param cause     exception cause
      */
     protected NashornException(final String msg, final Throwable cause) {
-        super(msg, cause == null ? null : cause);
+        super(msg, cause);
         // Hard luck - no column number info
         this.column = -1;
         // We can retrieve the line number and file name from the stack trace if needed

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/api/scripting/NashornScriptEngine.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/api/scripting/NashornScriptEngine.java
@@ -121,17 +121,14 @@ public final class NashornScriptEngine extends AbstractScriptEngine implements C
         // throw ParseException on first error from script
         final ErrorManager errMgr = new Context.ThrowErrorManager();
         // create new Nashorn Context
-        this.nashornContext = AccessController.doPrivileged(new PrivilegedAction<Context>() {
-            @Override
-            public Context run() {
-                try {
-                    return new Context(options, errMgr, appLoader, classFilter);
-                } catch (final RuntimeException e) {
-                    if (Context.DEBUG) {
-                        e.printStackTrace();
-                    }
-                    throw e;
+        this.nashornContext = AccessController.doPrivileged((PrivilegedAction<Context>) () -> {
+            try {
+                return new Context(options, errMgr, appLoader, classFilter);
+            } catch (final RuntimeException e) {
+                if (Context.DEBUG) {
+                    e.printStackTrace();
                 }
+                throw e;
             }
         }, CREATE_CONTEXT_ACC_CTXT);
 
@@ -342,17 +339,14 @@ public final class NashornScriptEngine extends AbstractScriptEngine implements C
 
     // Create a new Nashorn Global object
     private Global createNashornGlobal() {
-        final Global newGlobal = AccessController.doPrivileged(new PrivilegedAction<Global>() {
-            @Override
-            public Global run() {
-                try {
-                    return nashornContext.newGlobal();
-                } catch (final RuntimeException e) {
-                    if (Context.DEBUG) {
-                        e.printStackTrace();
-                    }
-                    throw e;
+        final Global newGlobal = AccessController.doPrivileged((PrivilegedAction<Global>) () -> {
+            try {
+                return nashornContext.newGlobal();
+            } catch (final RuntimeException e) {
+                if (Context.DEBUG) {
+                    e.printStackTrace();
                 }
+                throw e;
             }
         }, CREATE_GLOBAL_ACC_CTXT);
 

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/api/scripting/NashornScriptEngineFactory.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/api/scripting/NashornScriptEngineFactory.java
@@ -25,7 +25,6 @@
 
 package org.openjdk.nashorn.api.scripting;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -272,7 +271,7 @@ public final class NashornScriptEngineFactory implements ScriptEngineFactory {
     }
 
     private static List<String> immutableList(final String... elements) {
-        return Collections.unmodifiableList(Arrays.asList(elements));
+        return List.of(elements);
     }
 
     private static ClassLoader getAppClassLoader() {

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/api/scripting/ScriptObjectMirror.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/api/scripting/ScriptObjectMirror.java
@@ -90,12 +90,7 @@ public final class ScriptObjectMirror extends AbstractJSObject implements Bindin
 
     @Override
     public String toString() {
-        return inGlobal(new Callable<String>() {
-            @Override
-            public String call() {
-                return ScriptRuntime.safeToString(sobj);
-            }
-        });
+        return inGlobal(() -> ScriptRuntime.safeToString(sobj));
     }
 
     // JSObject methods
@@ -161,18 +156,12 @@ public final class ScriptObjectMirror extends AbstractJSObject implements Bindin
 
     @Override
     public Object eval(final String s) {
-        return inGlobal(new Callable<Object>() {
-            @Override
-            public Object call() {
-                final Context context = AccessController.doPrivileged(
-                        new PrivilegedAction<Context>() {
-                            @Override
-                            public Context run() {
-                                return Context.getContext();
-                            }
-                        }, GET_CONTEXT_ACC_CTXT);
-                return wrapLikeMe(context.eval(global, s, sobj, null));
-            }
+        return inGlobal(() -> {
+            final Context context = AccessController.doPrivileged(
+                (PrivilegedAction<Context>)Context::getContext,
+                GET_CONTEXT_ACC_CTXT
+            );
+            return wrapLikeMe(context.eval(global, s, sobj, null));
         });
     }
 
@@ -217,39 +206,23 @@ public final class ScriptObjectMirror extends AbstractJSObject implements Bindin
     @Override
     public Object getMember(final String name) {
         Objects.requireNonNull(name);
-        return inGlobal(new Callable<Object>() {
-            @Override public Object call() {
-                return wrapLikeMe(sobj.get(name));
-            }
-        });
+        return inGlobal(() -> wrapLikeMe(sobj.get(name)));
     }
 
     @Override
     public Object getSlot(final int index) {
-        return inGlobal(new Callable<Object>() {
-            @Override public Object call() {
-                return wrapLikeMe(sobj.get(index));
-            }
-        });
+        return inGlobal(() -> wrapLikeMe(sobj.get(index)));
     }
 
     @Override
     public boolean hasMember(final String name) {
         Objects.requireNonNull(name);
-        return inGlobal(new Callable<Boolean>() {
-            @Override public Boolean call() {
-                return sobj.has(name);
-            }
-        });
+        return inGlobal(() -> sobj.has(name));
     }
 
     @Override
     public boolean hasSlot(final int slot) {
-        return inGlobal(new Callable<Boolean>() {
-            @Override public Boolean call() {
-                return sobj.has(slot);
-            }
-        });
+        return inGlobal(() -> sobj.has(slot));
     }
 
     @Override
@@ -264,12 +237,7 @@ public final class ScriptObjectMirror extends AbstractJSObject implements Bindin
 
     @Override
     public void setSlot(final int index, final Object value) {
-        inGlobal(new Callable<Void>() {
-            @Override public Void call() {
-                sobj.set(index, unwrap(value, global), getCallSiteFlags());
-                return null;
-            }
-        });
+        inGlobal(() -> sobj.set(index, unwrap(value, global), getCallSiteFlags()));
     }
 
     /**
@@ -279,12 +247,7 @@ public final class ScriptObjectMirror extends AbstractJSObject implements Bindin
      * @param buf external buffer - should be a nio ByteBuffer
      */
     public void setIndexedPropertiesToExternalArrayData(final ByteBuffer buf) {
-        inGlobal(new Callable<Void>() {
-            @Override public Void call() {
-                sobj.setArray(ArrayData.allocate(buf));
-                return null;
-            }
-        });
+        inGlobal(() -> sobj.setArray(ArrayData.allocate(buf)));
     }
 
     @Override
@@ -299,11 +262,7 @@ public final class ScriptObjectMirror extends AbstractJSObject implements Bindin
             return false;
         }
 
-        return inGlobal(new Callable<Boolean>() {
-            @Override public Boolean call() {
-                return sobj.isInstance(mirror.sobj);
-            }
-        });
+        return inGlobal(() -> sobj.isInstance(mirror.sobj));
     }
 
     @Override
@@ -330,83 +289,58 @@ public final class ScriptObjectMirror extends AbstractJSObject implements Bindin
 
     @Override
     public void clear() {
-        inGlobal(new Callable<Object>() {
-            @Override public Object call() {
-                sobj.clear(strict);
-                return null;
-            }
-        });
+        inGlobal(() -> sobj.clear(strict));
     }
 
     @Override
     public boolean containsKey(final Object key) {
         checkKey(key);
-        return inGlobal(new Callable<Boolean>() {
-            @Override public Boolean call() {
-                return sobj.containsKey(key);
-            }
-        });
+        return inGlobal(() -> sobj.containsKey(key));
     }
 
     @Override
     public boolean containsValue(final Object value) {
-        return inGlobal(new Callable<Boolean>() {
-            @Override public Boolean call() {
-                return sobj.containsValue(unwrap(value, global));
-            }
-        });
+        return inGlobal(() -> sobj.containsValue(unwrap(value, global)));
     }
 
     @Override
     public Set<Map.Entry<String, Object>> entrySet() {
-        return inGlobal(new Callable<Set<Map.Entry<String, Object>>>() {
-            @Override public Set<Map.Entry<String, Object>> call() {
-                final Iterator<String>               iter    = sobj.propertyIterator();
-                final Set<Map.Entry<String, Object>> entries = new LinkedHashSet<>();
+        return inGlobal(() -> {
+            final Iterator<String>           iter    = sobj.propertyIterator();
+            final Set<Entry<String, Object>> entries = new LinkedHashSet<>();
 
-                while (iter.hasNext()) {
-                    final String key   = iter.next();
-                    final Object value = translateUndefined(wrapLikeMe(sobj.get(key)));
-                    entries.add(new AbstractMap.SimpleImmutableEntry<>(key, value));
-                }
-
-                return Collections.unmodifiableSet(entries);
+            while (iter.hasNext()) {
+                final String key   = iter.next();
+                final Object value = translateUndefined(wrapLikeMe(sobj.get(key)));
+                entries.add(new AbstractMap.SimpleImmutableEntry<>(key, value));
             }
+
+            return Collections.unmodifiableSet(entries);
         });
     }
 
     @Override
     public Object get(final Object key) {
         checkKey(key);
-        return inGlobal(new Callable<Object>() {
-            @Override public Object call() {
-                return translateUndefined(wrapLikeMe(sobj.get(key)));
-            }
-        });
+        return inGlobal(() -> translateUndefined(wrapLikeMe(sobj.get(key))));
     }
 
     @Override
     public boolean isEmpty() {
-        return inGlobal(new Callable<Boolean>() {
-            @Override public Boolean call() {
-                return sobj.isEmpty();
-            }
-        });
+        return inGlobal(sobj::isEmpty);
     }
 
     @Override
     public Set<String> keySet() {
-        return inGlobal(new Callable<Set<String>>() {
-            @Override public Set<String> call() {
-                final Iterator<String> iter   = sobj.propertyIterator();
-                final Set<String>      keySet = new LinkedHashSet<>();
+        return inGlobal(() -> {
+            final Iterator<String> iter   = sobj.propertyIterator();
+            final Set<String>      keySet = new LinkedHashSet<>();
 
-                while (iter.hasNext()) {
-                    keySet.add(iter.next());
-                }
-
-                return Collections.unmodifiableSet(keySet);
+            while (iter.hasNext()) {
+                keySet.add(iter.next());
             }
+
+            return Collections.unmodifiableSet(keySet);
         });
     }
 
@@ -415,29 +349,24 @@ public final class ScriptObjectMirror extends AbstractJSObject implements Bindin
         checkKey(key);
         final ScriptObject oldGlobal = Context.getGlobal();
         final boolean globalChanged = (oldGlobal != global);
-        return inGlobal(new Callable<Object>() {
-            @Override public Object call() {
-                final Object modValue = globalChanged? wrapLikeMe(value, oldGlobal) : value;
-                return translateUndefined(wrapLikeMe(sobj.put(key, unwrap(modValue, global), strict)));
-            }
+        return inGlobal(() -> {
+            final Object modValue = globalChanged? wrapLikeMe(value, oldGlobal) : value;
+            return translateUndefined(wrapLikeMe(sobj.put(key, unwrap(modValue, global), strict)));
         });
     }
 
     @Override
-    public void putAll(final Map<? extends String, ? extends Object> map) {
+    public void putAll(final Map<? extends String, ?> map) {
         Objects.requireNonNull(map);
         final ScriptObject oldGlobal = Context.getGlobal();
         final boolean globalChanged = (oldGlobal != global);
-        inGlobal(new Callable<Object>() {
-            @Override public Object call() {
-                for (final Map.Entry<? extends String, ? extends Object> entry : map.entrySet()) {
-                    final Object value = entry.getValue();
-                    final Object modValue = globalChanged? wrapLikeMe(value, oldGlobal) : value;
-                    final String key = entry.getKey();
-                    checkKey(key);
-                    sobj.set(key, unwrap(modValue, global), getCallSiteFlags());
-                }
-                return null;
+        inGlobal(() -> {
+            for (final Entry<? extends String, ?> entry : map.entrySet()) {
+                final Object value = entry.getValue();
+                final Object modValue = globalChanged? wrapLikeMe(value, oldGlobal) : value;
+                final String key = entry.getKey();
+                checkKey(key);
+                sobj.set(key, unwrap(modValue, global), getCallSiteFlags());
             }
         });
     }
@@ -445,11 +374,7 @@ public final class ScriptObjectMirror extends AbstractJSObject implements Bindin
     @Override
     public Object remove(final Object key) {
         checkKey(key);
-        return inGlobal(new Callable<Object>() {
-            @Override public Object call() {
-                return translateUndefined(wrapLikeMe(sobj.remove(key, strict)));
-            }
-        });
+        return inGlobal(() -> translateUndefined(wrapLikeMe(sobj.remove(key, strict))));
     }
 
     /**
@@ -460,35 +385,25 @@ public final class ScriptObjectMirror extends AbstractJSObject implements Bindin
      * @return if the delete was successful or not
      */
     public boolean delete(final Object key) {
-        return inGlobal(new Callable<Boolean>() {
-            @Override public Boolean call() {
-                return sobj.delete(unwrap(key, global), strict);
-            }
-        });
+        return inGlobal(() -> sobj.delete(unwrap(key, global), strict));
     }
 
     @Override
     public int size() {
-        return inGlobal(new Callable<Integer>() {
-            @Override public Integer call() {
-                return sobj.size();
-            }
-        });
+        return inGlobal(sobj::size);
     }
 
     @Override
     public Collection<Object> values() {
-        return inGlobal(new Callable<Collection<Object>>() {
-            @Override public Collection<Object> call() {
-                final List<Object>     values = new ArrayList<>(size());
-                final Iterator<Object> iter   = sobj.valueIterator();
+        return inGlobal(() -> {
+            final List<Object>     values = new ArrayList<>(size());
+            final Iterator<Object> iter   = sobj.valueIterator();
 
-                while (iter.hasNext()) {
-                    values.add(translateUndefined(wrapLikeMe(iter.next())));
-                }
-
-                return Collections.unmodifiableList(values);
+            while (iter.hasNext()) {
+                values.add(translateUndefined(wrapLikeMe(iter.next())));
             }
+
+            return Collections.unmodifiableList(values);
         });
     }
 
@@ -499,11 +414,7 @@ public final class ScriptObjectMirror extends AbstractJSObject implements Bindin
      * @return __proto__ object.
      */
     public Object getProto() {
-        return inGlobal(new Callable<Object>() {
-            @Override public Object call() {
-                return wrapLikeMe(sobj.getProto());
-            }
-        });
+        return inGlobal(() -> wrapLikeMe(sobj.getProto()));
     }
 
     /**
@@ -511,12 +422,7 @@ public final class ScriptObjectMirror extends AbstractJSObject implements Bindin
      * @param proto new proto for this object
      */
     public void setProto(final Object proto) {
-        inGlobal(new Callable<Void>() {
-            @Override public Void call() {
-                sobj.setPrototypeOf(unwrap(proto, global));
-                return null;
-            }
-        });
+        inGlobal(() -> sobj.setPrototypeOf(unwrap(proto, global)));
     }
 
     /**
@@ -528,11 +434,7 @@ public final class ScriptObjectMirror extends AbstractJSObject implements Bindin
      * object, or undefined if absent.
      */
     public Object getOwnPropertyDescriptor(final String key) {
-        return inGlobal(new Callable<Object>() {
-            @Override public Object call() {
-                return wrapLikeMe(sobj.getOwnPropertyDescriptor(key));
-            }
-        });
+        return inGlobal(() -> wrapLikeMe(sobj.getOwnPropertyDescriptor(key)));
     }
 
     /**
@@ -542,11 +444,7 @@ public final class ScriptObjectMirror extends AbstractJSObject implements Bindin
      * @return Array of keys.
      */
     public String[] getOwnKeys(final boolean all) {
-        return inGlobal(new Callable<String[]>() {
-            @Override public String[] call() {
-                return sobj.getOwnKeys(all);
-            }
-        });
+        return inGlobal(() -> sobj.getOwnKeys(all));
     }
 
     /**
@@ -555,11 +453,9 @@ public final class ScriptObjectMirror extends AbstractJSObject implements Bindin
      * @return the object after being made non extensible
      */
     public ScriptObjectMirror preventExtensions() {
-        return inGlobal(new Callable<ScriptObjectMirror>() {
-            @Override public ScriptObjectMirror call() {
-                sobj.preventExtensions();
-                return ScriptObjectMirror.this;
-            }
+        return inGlobal(() -> {
+            sobj.preventExtensions();
+            return ScriptObjectMirror.this;
         });
     }
 
@@ -568,11 +464,7 @@ public final class ScriptObjectMirror extends AbstractJSObject implements Bindin
      * @return true if extensible
      */
     public boolean isExtensible() {
-        return inGlobal(new Callable<Boolean>() {
-            @Override public Boolean call() {
-                return sobj.isExtensible();
-            }
-        });
+        return inGlobal(sobj::isExtensible);
     }
 
     /**
@@ -580,11 +472,9 @@ public final class ScriptObjectMirror extends AbstractJSObject implements Bindin
      * @return the sealed script object
      */
     public ScriptObjectMirror seal() {
-        return inGlobal(new Callable<ScriptObjectMirror>() {
-            @Override public ScriptObjectMirror call() {
-                sobj.seal();
-                return ScriptObjectMirror.this;
-            }
+        return inGlobal(() -> {
+            sobj.seal();
+            return ScriptObjectMirror.this;
         });
     }
 
@@ -593,11 +483,7 @@ public final class ScriptObjectMirror extends AbstractJSObject implements Bindin
      * @return true if sealed
      */
     public boolean isSealed() {
-        return inGlobal(new Callable<Boolean>() {
-            @Override public Boolean call() {
-                return sobj.isSealed();
-            }
-        });
+        return inGlobal(sobj::isSealed);
     }
 
     /**
@@ -605,11 +491,9 @@ public final class ScriptObjectMirror extends AbstractJSObject implements Bindin
      * @return the frozen script object
      */
     public ScriptObjectMirror freeze() {
-        return inGlobal(new Callable<ScriptObjectMirror>() {
-            @Override public ScriptObjectMirror call() {
-                sobj.freeze();
-                return ScriptObjectMirror.this;
-            }
+        return inGlobal(() -> {
+            sobj.freeze();
+            return ScriptObjectMirror.this;
         });
     }
 
@@ -618,11 +502,7 @@ public final class ScriptObjectMirror extends AbstractJSObject implements Bindin
      * @return true if frozen
      */
     public boolean isFrozen() {
-        return inGlobal(new Callable<Boolean>() {
-            @Override public Boolean call() {
-                return sobj.isFrozen();
-            }
-        });
+        return inGlobal(sobj::isFrozen);
     }
 
     /**
@@ -643,12 +523,7 @@ public final class ScriptObjectMirror extends AbstractJSObject implements Bindin
      * @return converted object
      */
     public <T> T to(final Class<T> type) {
-        return inGlobal(new Callable<T>() {
-            @Override
-            public T call() {
-                return type.cast(ScriptUtils.convert(sobj, type));
-            }
-        });
+        return inGlobal(() -> type.cast(ScriptUtils.convert(sobj, type)));
     }
 
     /**
@@ -847,6 +722,13 @@ public final class ScriptObjectMirror extends AbstractJSObject implements Bindin
     }
 
     // internals only below this.
+    private void inGlobal(final Runnable r) {
+        inGlobal(() -> {
+            r.run();
+            return null;
+        });
+    }
+
     private <V> V inGlobal(final Callable<V> callable) {
         final Global oldGlobal = Context.getGlobal();
         final boolean globalChanged = (oldGlobal != global);
@@ -888,26 +770,20 @@ public final class ScriptObjectMirror extends AbstractJSObject implements Bindin
 
     @Override @Deprecated
     public double toNumber() {
-        return inGlobal(new Callable<Double>() {
-            @Override public Double call() {
-                return JSType.toNumber(sobj);
-            }
-        });
+        return inGlobal(() -> JSType.toNumber(sobj));
     }
 
     @Override
     public Object getDefaultValue(final Class<?> hint) {
-        return inGlobal(new Callable<Object>() {
-            @Override public Object call() {
-                try {
-                    return sobj.getDefaultValue(hint);
-                } catch (final ECMAException e) {
-                    // We're catching ECMAException (likely TypeError), and translating it to
-                    // UnsupportedOperationException. This in turn will be translated into TypeError of the
-                    // caller's Global by JSType#toPrimitive(JSObject,Class) therefore ensuring that it's
-                    // recognized as "instanceof TypeError" in the caller.
-                    throw new UnsupportedOperationException(e.getMessage(), e);
-                }
+        return inGlobal(() -> {
+            try {
+                return sobj.getDefaultValue(hint);
+            } catch (final ECMAException e) {
+                // We're catching ECMAException (likely TypeError), and translating it to
+                // UnsupportedOperationException. This in turn will be translated into TypeError of the
+                // caller's Global by JSType#toPrimitive(JSObject,Class) therefore ensuring that it's
+                // recognized as "instanceof TypeError" in the caller.
+                throw new UnsupportedOperationException(e.getMessage(), e);
             }
         });
     }

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/api/scripting/URLReader.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/api/scripting/URLReader.java
@@ -82,7 +82,7 @@ public final class URLReader extends Reader {
     }
 
     @Override
-    public int read(final char cbuf[], final int off, final int len) throws IOException {
+    public int read(final char[] cbuf, final int off, final int len) throws IOException {
         return getReader().read(cbuf, off, len);
     }
 

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/ApplySpecialization.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/ApplySpecialization.java
@@ -166,7 +166,6 @@ public final class ApplySpecialization extends SimpleNodeVisitor implements Logg
      */
     private static void checkValidTransform(final FunctionNode functionNode) {
 
-        final Set<Expression> argumentsFound = new HashSet<>();
         final Deque<Set<Expression>> stack = new ArrayDeque<>();
 
         //ensure that arguments is only passed as arg to apply
@@ -177,11 +176,7 @@ public final class ApplySpecialization extends SimpleNodeVisitor implements Logg
             }
 
             private boolean isArguments(final Expression expr) {
-                if (expr instanceof IdentNode && ARGUMENTS.equals(((IdentNode)expr).getName())) {
-                    argumentsFound.add(expr);
-                    return true;
-               }
-                return false;
+                return expr instanceof IdentNode && ARGUMENTS.equals(((IdentNode) expr).getName());
             }
 
             private boolean isParam(final String name) {

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/AssignSymbols.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/AssignSymbols.java
@@ -517,7 +517,7 @@ final class AssignSymbols extends SimpleNodeVisitor implements Loggable {
     public boolean enterFunctionNode(final FunctionNode functionNode) {
         start(functionNode, false);
 
-        thisProperties.push(new HashSet<String>());
+        thisProperties.push(new HashSet<>());
 
         // Every function has a body, even the ones skipped on reparse (they have an empty one). We're
         // asserting this as even for those, enterBlock() must be invoked to correctly process symbols that

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/CacheAst.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/CacheAst.java
@@ -30,7 +30,6 @@ import java.util.Collections;
 import java.util.Deque;
 import org.openjdk.nashorn.internal.ir.FunctionNode;
 import org.openjdk.nashorn.internal.ir.Node;
-import org.openjdk.nashorn.internal.ir.Statement;
 import org.openjdk.nashorn.internal.ir.visitor.SimpleNodeVisitor;
 import org.openjdk.nashorn.internal.runtime.RecompilableScriptFunctionData;
 
@@ -78,7 +77,7 @@ class CacheAst extends SimpleNodeVisitor {
             // functions' bodies. Note we're doing this only for functions directly nested inside split
             // functions, since we're only caching the split ones. It is not necessary to limit body removal
             // to just these functions, but it's a cheap way to prevent unnecessary AST mutations.
-            return functionNode.setBody(lc, functionNode.getBody().setStatements(null, Collections.<Statement>emptyList()));
+            return functionNode.setBody(lc, functionNode.getBody().setStatements(null, Collections.emptyList()));
         }
         return functionNode;
     }

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/ClassEmitter.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/ClassEmitter.java
@@ -679,7 +679,7 @@ public class ClassEmitter {
      * separating these from the underlying bytecode emitter. Flags are provided
      * for method handles, protection levels, static/virtual fields/methods.
      */
-    static enum Flag {
+    enum Flag {
         /** method handle with static access */
         HANDLE_STATIC(H_INVOKESTATIC),
         /** method handle with new invoke special access */
@@ -702,7 +702,7 @@ public class ClassEmitter {
 
         private final int value;
 
-        private Flag(final int value) {
+        Flag(final int value) {
             this.value = value;
         }
 

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/ClassEmitter.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/ClassEmitter.java
@@ -37,7 +37,6 @@ import static org.objectweb.asm.Opcodes.H_INVOKESTATIC;
 import static org.objectweb.asm.Opcodes.H_INVOKEVIRTUAL;
 import static org.objectweb.asm.Opcodes.H_NEWINVOKESPECIAL;
 import static org.objectweb.asm.Opcodes.V1_7;
-import static org.openjdk.nashorn.internal.codegen.CompilerConstants.CLINIT;
 import static org.openjdk.nashorn.internal.codegen.CompilerConstants.CONSTANTS;
 import static org.openjdk.nashorn.internal.codegen.CompilerConstants.GET_ARRAY_PREFIX;
 import static org.openjdk.nashorn.internal.codegen.CompilerConstants.GET_ARRAY_SUFFIX;
@@ -135,8 +134,6 @@ public class ClassEmitter {
 
     private int initCount;
 
-    private int clinitCount;
-
     private int fieldCount;
 
     private final Set<String> methodNames;
@@ -231,15 +228,6 @@ public class ClassEmitter {
      */
     public int getMethodCount() {
         return methodCount;
-    }
-
-    /**
-     * Get the clinit count.
-     *
-     * @return clinit count
-     */
-    public int getClinitCount() {
-        return clinitCount;
     }
 
     /**
@@ -567,17 +555,6 @@ public class ClassEmitter {
             null);
 
         return new MethodEmitter(this, mv, functionNode);
-    }
-
-
-    /**
-     * Start generating the <clinit> method in the class.
-     *
-     * @return method emitter to use for weaving <clinit>
-     */
-    MethodEmitter clinit() {
-        clinitCount++;
-        return method(EnumSet.of(Flag.STATIC), CLINIT.symbolName(), void.class);
     }
 
     /**

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/ClassEmitter.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/ClassEmitter.java
@@ -142,7 +142,7 @@ public class ClassEmitter {
      * Constructor - only used internally in this class as it breaks
      * abstraction towards ASM or other code generator below.
      *
-     * @param env script environment
+     * @param context script context
      * @param cw  ASM classwriter
      */
     private ClassEmitter(final Context context, final ClassWriter cw) {
@@ -164,7 +164,7 @@ public class ClassEmitter {
     /**
      * Constructor.
      *
-     * @param env             script environment
+     * @param context         script context
      * @param className       name of class to weave
      * @param superClassName  super class name for class
      * @param interfaceNames  names of interfaces implemented by this class, or
@@ -178,7 +178,7 @@ public class ClassEmitter {
     /**
      * Constructor from the compiler.
      *
-     * @param env           Script environment
+     * @param context       Script context
      * @param sourceName    Source name
      * @param unitClassName Compile unit class name.
      * @param strictMode    Should we generate this method in strict mode

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/ClassEmitter.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/ClassEmitter.java
@@ -444,12 +444,7 @@ public class ClassEmitter {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (final PrintWriter pw = new PrintWriter(baos)) {
             final NashornClassReader cr = new NashornClassReader(bytecode);
-            final Context ctx = AccessController.doPrivileged(new PrivilegedAction<Context>() {
-                @Override
-                public Context run() {
-                    return Context.getContext();
-                }
-            });
+            final Context ctx = AccessController.doPrivileged((PrivilegedAction<Context>) Context::getContext);
             final TraceClassVisitor tcv = new TraceClassVisitor(null, new NashornTextifier(ctx.getEnv(), cr), pw);
             cr.accept(tcv, 0);
         }

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/ClassEmitter.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/ClassEmitter.java
@@ -196,7 +196,7 @@ public class ClassEmitter {
                     try {
                         return super.getCommonSuperClass(type1, type2);
                     } catch (final RuntimeException e) {
-                        if (isScriptObject(Compiler.SCRIPTS_PACKAGE, type1) && isScriptObject(Compiler.SCRIPTS_PACKAGE, type2)) {
+                        if (isScriptObject(type1) && isScriptObject(type2)) {
                             return className(ScriptObject.class);
                         }
                         return OBJECT_CLASS;
@@ -386,21 +386,16 @@ public class ClassEmitter {
     /**
      * Inspect class name and decide whether we are generating a ScriptObject class.
      *
-     * @param scriptPrefix the script class prefix for the current script
      * @param type         the type to check
      *
      * @return {@code true} if type is ScriptObject
      */
-    private static boolean isScriptObject(final String scriptPrefix, final String type) {
-        if (type.startsWith(scriptPrefix)) {
-            return true;
-        } else if (type.equals(CompilerConstants.className(ScriptObject.class))) {
-            return true;
-        } else if (type.startsWith(Compiler.OBJECTS_PACKAGE)) {
-            return true;
-        }
-
-        return false;
+    private static boolean isScriptObject(final String type) {
+        return
+            type.startsWith(Compiler.SCRIPTS_PACKAGE) ||
+            type.equals(CompilerConstants.className(ScriptObject.class)) ||
+            type.startsWith(Compiler.OBJECTS_PACKAGE)
+        ;
     }
 
     /**
@@ -449,8 +444,7 @@ public class ClassEmitter {
             cr.accept(tcv, 0);
         }
 
-        final String str = new String(baos.toByteArray());
-        return str;
+        return new String(baos.toByteArray());
     }
 
     /**
@@ -666,12 +660,11 @@ public class ClassEmitter {
      *         generation hasn't been ended with {@link ClassEmitter#end()}.
      */
     byte[] toByteArray() {
-        assert classEnded;
-        if (!classEnded) {
-            return null;
+        if (classEnded) {
+            return cw.toByteArray();
+        } else {
+            throw new AssertionError();
         }
-
-        return cw.toByteArray();
     }
 
     /**

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/CodeGenerator.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/CodeGenerator.java
@@ -3221,18 +3221,16 @@ final class CodeGenerator extends NodeOperatorVisitor<CodeGeneratorLexicalContex
         method._catch(recovery);
         method.store(vmException, EXCEPTION_TYPE);
 
-        final int catchBlockCount = catchBlocks.size();
         final Label afterCatch = new Label("after_catch");
-        for (int i = 0; i < catchBlockCount; i++) {
+        for (Block catchBlock : catchBlocks) {
             assert method.isReachable();
-            final Block catchBlock = catchBlocks.get(i);
 
             // Because of the peculiarities of the flow control, we need to use an explicit push/enterBlock/leaveBlock
             // here.
             lc.push(catchBlock);
             enterBlock(catchBlock);
 
-            final CatchNode  catchNode          = (CatchNode)catchBlocks.get(i).getStatements().get(0);
+            final CatchNode  catchNode          = (CatchNode)catchBlock.getStatements().get(0);
             final IdentNode  exception          = catchNode.getExceptionIdentifier();
             final Expression exceptionCondition = catchNode.getExceptionCondition();
             final Block      catchBody          = catchNode.getBody();
@@ -3277,8 +3275,8 @@ final class CodeGenerator extends NodeOperatorVisitor<CodeGeneratorLexicalContex
             catchBody.accept(this);
             leaveBlock(catchBlock);
             lc.pop(catchBlock);
-            if(nextCatch != null) {
-                if(method.isReachable()) {
+            if (nextCatch != null) {
+                if (method.isReachable()) {
                     method._goto(afterCatch);
                 }
                 method.breakLabel(nextCatch, lc.getUsedSlotCount());

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/CodeGenerator.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/CodeGenerator.java
@@ -4517,7 +4517,7 @@ final class CodeGenerator extends NodeOperatorVisitor<CodeGeneratorLexicalContex
         }
 
         private void epilogue() {
-            /**
+            /*
              * Take the original target args from the stack and use them
              * together with the value to be stored to emit the store code
              *

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/CodeGenerator.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/CodeGenerator.java
@@ -4885,11 +4885,8 @@ final class CodeGenerator extends NodeOperatorVisitor<CodeGeneratorLexicalContex
         private void addUnwarrantedOptimismHandlerLabel(final List<Type> localTypes, final Label label) {
             final String lvarTypesDescriptor = getLvarTypesDescriptor(localTypes);
             final Map<String, Collection<Label>> unwarrantedOptimismHandlers = lc.getUnwarrantedOptimismHandlers();
-            Collection<Label> labels = unwarrantedOptimismHandlers.get(lvarTypesDescriptor);
-            if(labels == null) {
-                labels = new LinkedList<>();
-                unwarrantedOptimismHandlers.put(lvarTypesDescriptor, labels);
-            }
+            Collection<Label> labels = unwarrantedOptimismHandlers
+                .computeIfAbsent(lvarTypesDescriptor, k -> new LinkedList<>());
             method.markLabelAsOptimisticCatchHandler(label, localTypes.size());
             labels.add(label);
         }

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/CodeGenerator.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/CodeGenerator.java
@@ -862,7 +862,7 @@ final class CodeGenerator extends NodeOperatorVisitor<CodeGeneratorLexicalContex
         final CodeGenerator codegen = this;
 
         final boolean isCurrentDiscard = codegen.lc.isCurrentDiscard(expr);
-        expr.accept(new NodeOperatorVisitor<LexicalContext>(new LexicalContext()) {
+        expr.accept(new NodeOperatorVisitor<>(new LexicalContext()) {
             @Override
             public boolean enterIdentNode(final IdentNode identNode) {
                 loadIdent(identNode, resultBounds);
@@ -1892,7 +1892,7 @@ final class CodeGenerator extends NodeOperatorVisitor<CodeGeneratorLexicalContex
                         assert !symbol.hasSlot()  : "slot for " + symbol + " should have been removed in Lower already" + function.getName();
 
                         //this tuple will not be put fielded, as it has no value, just a symbol
-                        tuples.add(new MapTuple<Symbol>(symbol.getName(), symbol, null));
+                        tuples.add(new MapTuple<>(symbol.getName(), symbol, null));
                     } else {
                         assert symbol.hasSlot() || symbol.slotCount() == 0 : symbol + " should have a slot only, no scope";
                     }
@@ -1923,7 +1923,7 @@ final class CodeGenerator extends NodeOperatorVisitor<CodeGeneratorLexicalContex
                         }
                     }
 
-                    tuples.add(new MapTuple<Symbol>(symbol.getName(), symbol, paramType, paramSymbol) {
+                    tuples.add(new MapTuple<>(symbol.getName(), symbol, paramType, paramSymbol) {
                         //this symbol will be put fielded, we can't initialize it as undefined with a known type
                         @Override
                         public Class<?> getValueType() {
@@ -2534,7 +2534,7 @@ final class CodeGenerator extends NodeOperatorVisitor<CodeGeneratorLexicalContex
             //for literals, a value of null means object type, i.e. the value null or getter setter function
             //(I think)
             final Class<?> valueType = (!useDualFields() || isComputedOrAccessor || value.getType().isBoolean()) ? Object.class : value.getType().getTypeClass();
-            tuples.add(new MapTuple<Expression>(key, symbol, Type.typeFor(valueType), value) {
+            tuples.add(new MapTuple<>(key, symbol, Type.typeFor(valueType), value) {
                 @Override
                 public Class<?> getValueType() {
                     return type.getTypeClass();
@@ -2546,7 +2546,7 @@ final class CodeGenerator extends NodeOperatorVisitor<CodeGeneratorLexicalContex
         if (elements.size() > OBJECT_SPILL_THRESHOLD) {
             oc = new SpillObjectCreator(this, tuples);
         } else {
-            oc = new FieldObjectCreator<Expression>(this, tuples) {
+            oc = new FieldObjectCreator<>(this, tuples) {
                 @Override
                 protected void loadValue(final Expression node, final Type type) {
                     // Use generic type in order to avoid conversion between object types

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/CodeGenerator.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/CodeGenerator.java
@@ -5094,7 +5094,7 @@ final class CodeGenerator extends NodeOperatorVisitor<CodeGeneratorLexicalContex
         for(final String spec: unwarrantedOptimismHandlers.keySet()) {
             handlerSpecs.add(new OptimismExceptionHandlerSpec(spec, true));
         }
-        Collections.sort(handlerSpecs, Collections.reverseOrder());
+        handlerSpecs.sort(Collections.reverseOrder());
 
         // Map of local variable specifications to labels for populating the array for that local variable spec.
         final Map<String, Label> delegationLabels = new HashMap<>();

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/CodeGenerator.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/CodeGenerator.java
@@ -2519,7 +2519,7 @@ final class CodeGenerator extends NodeOperatorVisitor<CodeGeneratorLexicalContex
                 // Properties with computed names or getter/setters need special handling.
                 specialProperties.add(propertyNode);
             } else if (propertyNode.getKey() instanceof IdentNode &&
-                       key.equals(ScriptObject.PROTO_PROPERTY_NAME)) {
+                       ScriptObject.PROTO_PROPERTY_NAME.equals(key)) {
                 // ES6 draft compliant __proto__ inside object literal
                 // Identifier key and name is __proto__
                 protoNode = value;

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/CodeGenerator.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/CodeGenerator.java
@@ -2273,15 +2273,12 @@ final class CodeGenerator extends NodeOperatorVisitor<CodeGeneratorLexicalContex
 
         if (ranges != null) {
 
-            loadSplitLiteral(new SplitLiteralCreator() {
-                @Override
-                public void populateRange(final MethodEmitter method, final Type type, final int slot, final int start, final int end) {
-                    for (int i = start; i < end; i++) {
-                        method.load(type, slot);
-                        storeElement(nodes, elementType, postsets[i]);
-                    }
+            loadSplitLiteral((method, type, slot, start, end) -> {
+                for (int i = start; i < end; i++) {
                     method.load(type, slot);
+                    storeElement(nodes, elementType, postsets[i]);
                 }
+                method.load(type, slot);
             }, ranges, arrayType);
 
             return;

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/CodeGenerator.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/CodeGenerator.java
@@ -530,7 +530,7 @@ final class CodeGenerator extends NodeOperatorVisitor<CodeGeneratorLexicalContex
 
         final int internalDepth = FindScopeDepths.findInternalDepth(lc, fn, startingBlock, symbol);
         final int scopesToStart = FindScopeDepths.findScopesToStart(lc, fn, startingBlock);
-        int depth = 0;
+        final int depth;
         if (internalDepth == -1) {
             depth = scopesToStart + externalDepth;
         } else {

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/CodeGeneratorLexicalContext.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/CodeGeneratorLexicalContext.java
@@ -141,7 +141,7 @@ final class CodeGeneratorLexicalContext extends LexicalContext {
     }
 
     void pushUnwarrantedOptimismHandlers() {
-        unwarrantedOptimismHandlers.push(new HashMap<String, Collection<Label>>());
+        unwarrantedOptimismHandlers.push(new HashMap<>());
         slotTypesDescriptors.push(new StringBuilder());
     }
 

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/CompilationException.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/CompilationException.java
@@ -34,8 +34,4 @@ public class CompilationException extends RuntimeException {
     CompilationException(final String description) {
         super(description);
     }
-
-    CompilationException(final Exception cause) {
-        super(cause);
-    }
 }

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/CompilationPhase.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/CompilationPhase.java
@@ -555,9 +555,6 @@ abstract class CompilationPhase {
     /** start time of transform - used for timing, see {@link org.openjdk.nashorn.internal.runtime.Timing} */
     private long endTime;
 
-    /** boolean that is true upon transform completion */
-    private boolean isFinished;
-
     private CompilationPhase() {}
 
     /**
@@ -584,12 +581,7 @@ abstract class CompilationPhase {
         endTime = System.nanoTime();
         compiler.getScriptEnvironment()._timing.accumulateTime(toString(), endTime - startTime);
 
-        isFinished = true;
         return functionNode;
-    }
-
-    boolean isFinished() {
-        return isFinished;
     }
 
     long getStartTime() {

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/CompilationPhase.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/CompilationPhase.java
@@ -531,20 +531,11 @@ abstract class CompilationPhase {
             }
 
             if (log.isEnabled()) {
-                final StringBuilder sb = new StringBuilder();
-
-                sb.append("Installed class '").
-                    append(rootClass.getSimpleName()).
-                    append('\'').
-                    append(" [").
-                    append(rootClass.getName()).
-                    append(", size=").
-                    append(length).
-                    append(" bytes, ").
-                    append(compiler.getCompileUnits().size()).
-                    append(" compile unit(s)]");
-
-                log.fine(sb.toString());
+                log.fine(
+                    "Installed class '" + rootClass.getSimpleName() + '\'' + " [" + rootClass
+                        .getName() + ", size=" + length + " bytes, " + compiler.getCompileUnits()
+                        .size() + " compile unit(s)]"
+                );
             }
 
             return fn.setRootClass(null, rootClass);

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/CompilationPhase.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/CompilationPhase.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import org.openjdk.nashorn.internal.codegen.Compiler.CompilationPhases;
 import org.openjdk.nashorn.internal.ir.Block;
@@ -329,7 +330,8 @@ abstract class CompilationPhase {
             //replace old compile units in function nodes, if any are assigned,
             //for example by running the splitter on this function node in a previous
             //partial code generation
-            final FunctionNode newFunctionNode = transformFunction(fn, new ReplaceCompileUnits() {
+
+            return transformFunction(fn, new ReplaceCompileUnits() {
                 @Override
                 CompileUnit getReplacement(final CompileUnit original) {
                     return map.get(original);
@@ -340,8 +342,6 @@ abstract class CompilationPhase {
                     return node.ensureUniqueLabels(lc);
                 }
             });
-
-            return newFunctionNode;
         }
 
         @Override
@@ -370,10 +370,10 @@ abstract class CompilationPhase {
                 @Override
                 CompileUnit getReplacement(final CompileUnit oldUnit) {
                     final CompileUnit existing = unitMap.get(oldUnit);
-                    if (existing != null) {
-                        return existing;
-                    }
-                    return createCompileUnit(oldUnit, unitSet, unitMap, compiler, phases);
+                    return Objects.requireNonNullElseGet(
+                        existing,
+                        () -> createCompileUnit(oldUnit, unitSet, unitMap, compiler, phases)
+                    );
                 }
 
                 @Override

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/CompileUnit.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/CompileUnit.java
@@ -97,7 +97,7 @@ public final class CompileUnit implements Comparable<CompileUnit>, Serializable 
      * @return true of if there is "real code" in the compile unit
      */
     public boolean hasCode() {
-        return (classEmitter.getMethodCount() - classEmitter.getInitCount() - classEmitter.getClinitCount()) > 0;
+        return (classEmitter.getMethodCount() - classEmitter.getInitCount()) > 0;
     }
 
     /**

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/Compiler.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/Compiler.java
@@ -265,10 +265,6 @@ public final class Compiler implements Loggable {
             this(desc, concat(Collections.singletonList(first), rest.phases));
         }
 
-        private CompilationPhases(final String desc, final CompilationPhases base) {
-            this(desc, base.phases);
-        }
-
         private CompilationPhases(final String desc, final CompilationPhases... bases) {
             this(desc, concatPhases(bases));
         }
@@ -314,14 +310,6 @@ public final class Compiler implements Loggable {
 
         String getDesc() {
             return desc;
-        }
-
-        String toString(final String prefix) {
-            final StringBuilder sb = new StringBuilder();
-            for (final CompilationPhase phase : phases) {
-                sb.append(prefix).append(phase).append('\n');
-            }
-            return sb.toString();
         }
     }
 

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/Compiler.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/Compiler.java
@@ -332,7 +332,7 @@ public final class Compiler implements Loggable {
      * See {@link CompilerConstants} for special names used for structures
      * during a compile.
      */
-    private static String[] RESERVED_NAMES = {
+    private static final String[] RESERVED_NAMES = {
         SCOPE.symbolName(),
         THIS.symbolName(),
         RETURN.symbolName(),

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/Compiler.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/Compiler.java
@@ -47,7 +47,6 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
 import java.util.logging.Level;
 import org.openjdk.nashorn.internal.codegen.types.Type;
 import org.openjdk.nashorn.internal.ir.Expression;

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/Compiler.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/Compiler.java
@@ -543,14 +543,11 @@ public final class Compiler implements Loggable {
         final boolean optimisticTypes = env._optimistic_types;
         final boolean lazyCompilation = env._lazy_compilation;
 
-        return ctxt.getLogger(this.getClass(), new Consumer<DebugLogger>() {
-            @Override
-            public void accept(final DebugLogger newLogger) {
-                if (!lazyCompilation) {
-                    newLogger.warning("WARNING: Running with lazy compilation switched off. This is not a default setting.");
-                }
-                newLogger.warning("Optimistic types are ", optimisticTypes ? "ENABLED." : "DISABLED.");
+        return ctxt.getLogger(this.getClass(), newLogger -> {
+            if (!lazyCompilation) {
+                newLogger.warning("WARNING: Running with lazy compilation switched off. This is not a default setting.");
             }
+            newLogger.warning("Optimistic types are ", optimisticTypes ? "ENABLED." : "DISABLED.");
         });
     }
 

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/CompilerConstants.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/CompilerConstants.java
@@ -57,9 +57,6 @@ public enum CompilerConstants {
     /** constructor name */
     INIT("<init>"),
 
-    /** static initializer name */
-    CLINIT("<clinit>"),
-
     /** eval name */
     EVAL("eval"),
 
@@ -184,16 +181,6 @@ public enum CompilerConstants {
 
     /** get array suffix */
     GET_ARRAY_SUFFIX("$array");
-
-    /** To save memory - intern the compiler constant symbol names, as they are frequently reused */
-    static {
-        for (final CompilerConstants c : values()) {
-            final String symbolName = c.symbolName();
-            if (symbolName != null) {
-                symbolName.intern();
-            }
-        }
-    }
 
     private static Set<String> symbolNames;
 

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/DumpBytecode.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/DumpBytecode.java
@@ -114,7 +114,7 @@ public final class DumpBytecode {
                     ": ",
                     ECMAErrors.getMessage(
                         "io.error.cant.write",
-                        dir.toString()));
+                        String.valueOf(dir)));
         }
     }
 }

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/FieldObjectCreator.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/FieldObjectCreator.java
@@ -38,7 +38,6 @@ import java.util.List;
 import org.openjdk.nashorn.internal.codegen.types.Type;
 import org.openjdk.nashorn.internal.ir.Symbol;
 import org.openjdk.nashorn.internal.runtime.Context;
-import org.openjdk.nashorn.internal.runtime.JSType;
 import org.openjdk.nashorn.internal.runtime.PropertyMap;
 import org.openjdk.nashorn.internal.runtime.ScriptObject;
 import org.openjdk.nashorn.internal.runtime.arrays.ArrayIndex;

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/FindScopeDepths.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/FindScopeDepths.java
@@ -164,12 +164,7 @@ final class FindScopeDepths extends SimpleNodeVisitor implements Loggable {
             increaseDynamicScopeCount(functionNode);
         }
 
-        final int fnId = functionNode.getId();
-        Map<Integer, RecompilableScriptFunctionData> nestedFunctions = fnIdToNestedFunctions.get(fnId);
-        if (nestedFunctions == null) {
-            nestedFunctions = new HashMap<>();
-            fnIdToNestedFunctions.put(fnId, nestedFunctions);
-        }
+        fnIdToNestedFunctions.computeIfAbsent(functionNode.getId(), k -> new HashMap<>());
 
         return true;
     }
@@ -348,13 +343,8 @@ final class FindScopeDepths extends SimpleNodeVisitor implements Loggable {
     }
 
     private void addExternalSymbol(final FunctionNode functionNode, final Symbol symbol, final int depthAtStart) {
-        final int fnId = functionNode.getId();
-        Map<String, Integer> depths = externalSymbolDepths.get(fnId);
-        if (depths == null) {
-            depths = new HashMap<>();
-            externalSymbolDepths.put(fnId, depths);
-        }
-        depths.put(symbol.getName(), depthAtStart);
+        externalSymbolDepths
+            .computeIfAbsent(functionNode.getId(), k -> new HashMap<>())
+            .put(symbol.getName(), depthAtStart);
     }
-
 }

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/FoldConstants.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/FoldConstants.java
@@ -278,12 +278,7 @@ final class FoldConstants extends SimpleNodeVisitor implements Loggable {
                 return result;
             }
 
-            result = reduceOneLiteral();
-            if (result != null) {
-                return result;
-            }
-
-            return null;
+            return reduceOneLiteral();
         }
 
         @SuppressWarnings("static-method")

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/FunctionSignature.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/FunctionSignature.java
@@ -123,14 +123,13 @@ public final class FunctionSignature {
 
         if (isVarArg) {
             paramTypes[next] = Type.OBJECT_ARRAY;
-        } else if (argTypes != null) {
+        } else {
+            assert argTypes != null : "isVarArgs cannot be false when argTypes are null";
             for (int j = 0; next < count;) {
                 final Type type = argTypes[j++];
                 // TODO: for now, turn java/lang/String into java/lang/Object as we aren't as specific.
                 paramTypes[next++] = type.isObject() ? Type.OBJECT : type;
             }
-        } else {
-            assert false : "isVarArgs cannot be false when argTypes are null";
         }
 
         this.returnType = retType;

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/Label.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/Label.java
@@ -480,9 +480,9 @@ public final class Label implements Serializable {
         @Override
         public String toString() {
             return "stack=" + Arrays.toString(Arrays.copyOf(data, sp))
-                 + ", symbolBoundaries=" + String.valueOf(symbolBoundary)
+                 + ", symbolBoundaries=" + symbolBoundary
                  + ", firstTemp=" + firstTemp
-                 + ", localTypes=" + String.valueOf(localVariableTypes)
+                 + ", localTypes=" + localVariableTypes
                  ;
         }
     }

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/Label.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/Label.java
@@ -200,10 +200,9 @@ public final class Label implements Serializable {
 
         private int getFirstDeadLocal(final List<Type> types) {
             int i = types.size();
-            for(final ListIterator<Type> it = types.listIterator(i);
-                it.hasPrevious() && it.previous() == Type.UNKNOWN;
-                --i) {
-                // no body
+            final ListIterator<Type> it = types.listIterator(i);
+            while (it.hasPrevious() && it.previous() == Type.UNKNOWN) {
+                --i;
             }
 
             // Respect symbol boundaries; we never chop off half a symbol's storage

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/Label.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/Label.java
@@ -73,10 +73,6 @@ public final class Label implements Serializable {
             return sp;
         }
 
-        void clear() {
-            sp = 0;
-        }
-
         void push(final Type type) {
             if (data.length == sp) {
                 final Type[] newData = new Type[sp * 2];

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/LocalVariableTypesCalculator.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/LocalVariableTypesCalculator.java
@@ -43,7 +43,6 @@ import java.util.Map;
 import java.util.Set;
 import org.openjdk.nashorn.internal.codegen.types.Type;
 import org.openjdk.nashorn.internal.ir.AccessNode;
-import org.openjdk.nashorn.internal.ir.BaseNode;
 import org.openjdk.nashorn.internal.ir.BinaryNode;
 import org.openjdk.nashorn.internal.ir.Block;
 import org.openjdk.nashorn.internal.ir.BreakNode;

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/BinaryNode.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/BinaryNode.java
@@ -27,9 +27,6 @@ package org.openjdk.nashorn.internal.ir;
 
 import static org.openjdk.nashorn.internal.runtime.UnwarrantedOptimismException.INVALID_PROGRAM_POINT;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 import org.openjdk.nashorn.internal.codegen.types.Type;
 import org.openjdk.nashorn.internal.ir.annotations.Ignore;

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/BinaryNode.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/BinaryNode.java
@@ -60,20 +60,20 @@ public final class BinaryNode extends Expression implements Assignment<Expressio
 
     @Ignore
     private static final Set<TokenType> CAN_OVERFLOW =
-        Collections.unmodifiableSet(new HashSet<>(Arrays.asList(new TokenType[] {
-                TokenType.ADD,
-                TokenType.DIV,
-                TokenType.MOD,
-                TokenType.MUL,
-                TokenType.SUB,
-                TokenType.ASSIGN_ADD,
-                TokenType.ASSIGN_DIV,
-                TokenType.ASSIGN_MOD,
-                TokenType.ASSIGN_MUL,
-                TokenType.ASSIGN_SUB,
-                TokenType.SHR,
-                TokenType.ASSIGN_SHR
-            })));
+        Set.of(
+            TokenType.ADD,
+            TokenType.DIV,
+            TokenType.MOD,
+            TokenType.MUL,
+            TokenType.SUB,
+            TokenType.ASSIGN_ADD,
+            TokenType.ASSIGN_DIV,
+            TokenType.ASSIGN_MOD,
+            TokenType.ASSIGN_MUL,
+            TokenType.ASSIGN_SUB,
+            TokenType.SHR,
+            TokenType.ASSIGN_SHR
+        );
 
     /**
      * Constructor

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/Block.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/Block.java
@@ -27,7 +27,6 @@ package org.openjdk.nashorn.internal.ir;
 
 import java.io.PrintWriter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
@@ -42,6 +41,8 @@ import org.openjdk.nashorn.internal.ir.visitor.NodeVisitor;
  */
 @Immutable
 public class Block extends Node implements BreakableNode, Terminal, Flags<Block> {
+    private static final Comparator<Symbol> SYMBOL_NAME_COMPARATOR = Comparator.comparing(Symbol::getName);
+
     private static final long serialVersionUID = 1L;
 
     /** List of statements */
@@ -116,7 +117,7 @@ public class Block extends Node implements BreakableNode, Terminal, Flags<Block>
     public Block(final long token, final int finish, final int flags, final Statement... statements) {
         super(token, finish);
 
-        this.statements = Arrays.asList(statements);
+        this.statements = List.of(statements);
         this.symbols    = new LinkedHashMap<>();
         this.entryLabel = new Label("block_entry");
         this.breakLabel = new Label("block_break");
@@ -243,7 +244,7 @@ public class Block extends Node implements BreakableNode, Terminal, Flags<Block>
      * @return symbol iterator
      */
     public List<Symbol> getSymbols() {
-        return symbols.isEmpty() ? Collections.emptyList() : Collections.unmodifiableList(new ArrayList<>(symbols.values()));
+        return symbols.isEmpty() ? List.of() : List.copyOf(symbols.values());
     }
 
     /**
@@ -285,12 +286,7 @@ public class Block extends Node implements BreakableNode, Terminal, Flags<Block>
     public boolean printSymbols(final PrintWriter stream) {
         final List<Symbol> values = new ArrayList<>(symbols.values());
 
-        Collections.sort(values, new Comparator<Symbol>() {
-            @Override
-            public int compare(final Symbol s0, final Symbol s1) {
-                return s0.getName().compareTo(s1.getName());
-            }
-        });
+        values.sort(SYMBOL_NAME_COMPARATOR);
 
         for (final Symbol symbol : values) {
             symbol.print(stream);
@@ -503,7 +499,7 @@ public class Block extends Node implements BreakableNode, Terminal, Flags<Block>
 
     @Override
     public List<Label> getLabels() {
-        return Collections.unmodifiableList(Arrays.asList(entryLabel, breakLabel));
+        return List.of(entryLabel, breakLabel);
     }
 
     @Override

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/CaseNode.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/CaseNode.java
@@ -25,7 +25,6 @@
 
 package org.openjdk.nashorn.internal.ir;
 
-import java.util.Collections;
 import java.util.List;
 import org.openjdk.nashorn.internal.codegen.Label;
 import org.openjdk.nashorn.internal.ir.annotations.Immutable;
@@ -174,6 +173,6 @@ public final class CaseNode extends Node implements JoinPredecessor, Labels, Ter
 
     @Override
     public List<Label> getLabels() {
-        return Collections.unmodifiableList(Collections.singletonList(entry));
+        return List.of(entry);
     }
 }

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/LiteralNode.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/LiteralNode.java
@@ -289,10 +289,6 @@ public abstract class LiteralNode<T> extends Expression implements PropertyKey {
             super(token, finish, value);
         }
 
-        private PrimitiveLiteralNode(final PrimitiveLiteralNode<T> literalNode) {
-            super(literalNode);
-        }
-
         /**
          * Check if the literal value is boolean true
          * @return true if literal value is boolean true
@@ -323,10 +319,6 @@ public abstract class LiteralNode<T> extends Expression implements PropertyKey {
 
         private BooleanLiteralNode(final long token, final int finish, final boolean value) {
             super(Token.recast(token, value ? TokenType.TRUE : TokenType.FALSE), finish, value);
-        }
-
-        private BooleanLiteralNode(final BooleanLiteralNode literalNode) {
-            super(literalNode);
         }
 
         @Override
@@ -378,10 +370,6 @@ public abstract class LiteralNode<T> extends Expression implements PropertyKey {
 
         private NumberLiteralNode(final long token, final int finish, final Number value) {
             super(Token.recast(token, TokenType.DECIMAL), finish, value);
-        }
-
-        private NumberLiteralNode(final NumberLiteralNode literalNode) {
-            super(literalNode);
         }
 
         private static Type numberGetType(final Number number) {
@@ -439,10 +427,6 @@ public abstract class LiteralNode<T> extends Expression implements PropertyKey {
         private UndefinedLiteralNode(final long token, final int finish) {
             super(Token.recast(token, TokenType.OBJECT), finish, ScriptRuntime.UNDEFINED);
         }
-
-        private UndefinedLiteralNode(final UndefinedLiteralNode literalNode) {
-            super(literalNode);
-        }
     }
 
     /**
@@ -476,10 +460,6 @@ public abstract class LiteralNode<T> extends Expression implements PropertyKey {
 
         private StringLiteralNode(final long token, final int finish, final String value) {
             super(Token.recast(token, TokenType.STRING), finish, value);
-        }
-
-        private StringLiteralNode(final StringLiteralNode literalNode) {
-            super(literalNode);
         }
 
         @Override
@@ -521,10 +501,6 @@ public abstract class LiteralNode<T> extends Expression implements PropertyKey {
 
         private LexerTokenLiteralNode(final long token, final int finish, final LexerToken value) {
             super(Token.recast(token, TokenType.STRING), finish, value); //TODO is string the correct token type here?
-        }
-
-        private LexerTokenLiteralNode(final LexerTokenLiteralNode literalNode) {
-            super(literalNode);
         }
 
         @Override
@@ -703,14 +679,6 @@ public abstract class LiteralNode<T> extends Expression implements PropertyKey {
                 return false;
             }
 
-            private static boolean setArrayElement(final long[] array, final int i, final Object n) {
-                if (n instanceof Number) {
-                    array[i] = ((Number)n).longValue();
-                    return true;
-                }
-                return false;
-            }
-
             private static boolean setArrayElement(final double[] array, final int i, final Object n) {
                 if (n instanceof Number) {
                     array[i] = ((Number)n).doubleValue();
@@ -721,18 +689,6 @@ public abstract class LiteralNode<T> extends Expression implements PropertyKey {
 
             private static int[] presetIntArray(final Expression[] value, final int[] postsets) {
                 final int[] array = new int[value.length];
-                int nComputed = 0;
-                for (int i = 0; i < value.length; i++) {
-                    if (!setArrayElement(array, i, objectAsConstant(value[i]))) {
-                        assert postsets[nComputed++] == i;
-                    }
-                }
-                assert postsets.length == nComputed;
-                return array;
-            }
-
-            private static long[] presetLongArray(final Expression[] value, final int[] postsets) {
-                final long[] array = new long[value.length];
                 int nComputed = 0;
                 for (int i = 0; i < value.length; i++) {
                     if (!setArrayElement(array, i, objectAsConstant(value[i]))) {

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/LocalVariableConversion.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/LocalVariableConversion.java
@@ -116,7 +116,7 @@ public final class LocalVariableConversion {
 
     /**
      * Returns true if the passed conversion is not null, and it {@link #isAnyLive()}.
-     * @parameter conv the conversion being tested for liveness.
+     * @param conv the conversion being tested for liveness.
      * @return true if the conversion is not null and {@link #isAnyLive()}.
      */
     private static boolean isAnyLive(final LocalVariableConversion conv) {

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/LoopNode.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/LoopNode.java
@@ -25,8 +25,6 @@
 
 package org.openjdk.nashorn.internal.ir;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import org.openjdk.nashorn.internal.codegen.Label;
 
@@ -130,7 +128,7 @@ public abstract class LoopNode extends BreakableStatement {
 
     @Override
     public List<Label> getLabels() {
-        return Collections.unmodifiableList(Arrays.asList(breakLabel, continueLabel));
+        return List.of(breakLabel, continueLabel);
     }
 
     @Override

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/OptimisticLexicalContext.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/OptimisticLexicalContext.java
@@ -39,7 +39,7 @@ public class OptimisticLexicalContext extends LexicalContext {
 
     private final boolean isEnabled;
 
-    class Assumption {
+    static class Assumption {
         Symbol symbol;
         Type   type;
 
@@ -107,7 +107,7 @@ public class OptimisticLexicalContext extends LexicalContext {
     public <T extends LexicalContextNode> T push(final T node) {
         if (isEnabled) {
             if(node instanceof FunctionNode) {
-                optimisticAssumptions.push(new ArrayList<Assumption>());
+                optimisticAssumptions.push(new ArrayList<>());
             }
         }
 

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/PropertyKey.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/PropertyKey.java
@@ -35,5 +35,5 @@ public interface PropertyKey {
      *
      * @return the property name
      */
-    public abstract String getPropertyName();
+    public String getPropertyName();
 }

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/PropertyNode.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/PropertyNode.java
@@ -113,7 +113,7 @@ public final class PropertyNode extends Node {
         }
 
         if (value != null) {
-            ((Node)key).toString(sb, printType);
+            key.toString(sb, printType);
             sb.append(": ");
             value.toString(sb, printType);
         }

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/ReturnNode.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/ReturnNode.java
@@ -73,14 +73,6 @@ public class ReturnNode extends Statement {
     }
 
     /**
-     * Check if this return node has an expression
-     * @return true if not a void return
-     */
-    public boolean hasExpression() {
-        return expression != null;
-    }
-
-    /**
      * Return true if is a YIELD node.
      * @return TRUE if is YIELD node.
      */

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/Symbol.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/Symbol.java
@@ -486,13 +486,11 @@ public final class Symbol implements Comparable<Symbol>, Cloneable, Serializable
      * and get allocated in a JO-prefixed ScriptObject subclass.
      *
      * @param fieldIndex field index - a positive integer
-     * @return the symbol
      */
-    public Symbol setFieldIndex(final int fieldIndex) {
+    public void setFieldIndex(final int fieldIndex) {
         if (this.fieldIndex != fieldIndex) {
             this.fieldIndex = fieldIndex;
         }
-        return this;
     }
 
     /**

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/Symbol.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/Symbol.java
@@ -158,7 +158,7 @@ public final class Symbol implements Comparable<Symbol>, Cloneable, Serializable
 
     private static String align(final String string, final int max) {
         final StringBuilder sb = new StringBuilder();
-        sb.append(string.substring(0, Math.min(string.length(), max)));
+        sb.append(string, 0, Math.min(string.length(), max));
 
         while (sb.length() < max) {
             sb.append(' ');

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/UnaryNode.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/UnaryNode.java
@@ -30,8 +30,6 @@ import static org.openjdk.nashorn.internal.parser.TokenType.DECPOSTFIX;
 import static org.openjdk.nashorn.internal.parser.TokenType.INCPOSTFIX;
 import static org.openjdk.nashorn.internal.runtime.UnwarrantedOptimismException.INVALID_PROGRAM_POINT;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import org.openjdk.nashorn.internal.codegen.types.Type;
 import org.openjdk.nashorn.internal.ir.annotations.Ignore;
@@ -55,16 +53,14 @@ public final class UnaryNode extends Expression implements Assignment<Expression
     private final Type type;
 
     @Ignore
-    private static final List<TokenType> CAN_OVERFLOW =
-            Collections.unmodifiableList(
-                Arrays.asList(new TokenType[] {
-                    TokenType.POS,
-                    TokenType.NEG, //negate
-                    TokenType.DECPREFIX,
-                    TokenType.DECPOSTFIX,
-                    TokenType.INCPREFIX,
-                    TokenType.INCPOSTFIX,
-                }));
+    private static final List<TokenType> CAN_OVERFLOW = List.of(
+        TokenType.POS,
+        TokenType.NEG,
+        TokenType.DECPREFIX,
+        TokenType.DECPOSTFIX,
+        TokenType.INCPREFIX,
+        TokenType.INCPOSTFIX
+    );
 
     /**
      * Constructor

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/UnaryNode.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/UnaryNode.java
@@ -199,14 +199,7 @@ public final class UnaryNode extends Expression implements Assignment<Expression
 
     @Override
     public void toString(final StringBuilder sb, final boolean printType) {
-        toString(sb,
-                new Runnable() {
-                    @Override
-                    public void run() {
-                        getExpression().toString(sb, printType);
-                    }
-                },
-                printType);
+        toString(sb, () -> getExpression().toString(sb, printType));
     }
 
     /**
@@ -214,10 +207,9 @@ public final class UnaryNode extends Expression implements Assignment<Expression
      * operand to a specified runnable.
      * @param sb the string builder to use
      * @param rhsStringBuilder the runnable that appends the string representation of the operand to the string builder
-     * @param printType should we print type
      * when invoked.
      */
-    public void toString(final StringBuilder sb, final Runnable rhsStringBuilder, final boolean printType) {
+    public void toString(final StringBuilder sb, final Runnable rhsStringBuilder) {
         final TokenType tokenType = tokenType();
         final String    name      = tokenType.getName();
         final boolean   isPostfix = tokenType == DECPOSTFIX || tokenType == INCPOSTFIX;

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/debug/PrintVisitor.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/debug/PrintVisitor.java
@@ -259,12 +259,7 @@ public final class PrintVisitor extends SimpleNodeVisitor {
 
     @Override
     public boolean enterUnaryNode(final UnaryNode unaryNode) {
-        unaryNode.toString(sb, new Runnable() {
-            @Override
-            public void run() {
-                unaryNode.getExpression().accept(PrintVisitor.this);
-            }
-        }, printTypes);
+        unaryNode.toString(sb, () -> unaryNode.getExpression().accept(PrintVisitor.this));
         return false;
     }
 

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/GenericPropertyDescriptor.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/GenericPropertyDescriptor.java
@@ -153,9 +153,7 @@ public final class GenericPropertyDescriptor extends ScriptObject implements Pro
         }
 
         if (has(ENUMERABLE) && other.has(ENUMERABLE)) {
-            if (isEnumerable() != other.isEnumerable()) {
-                return false;
-            }
+            return isEnumerable() == other.isEnumerable();
         }
 
         return true;

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/LinkedMap.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/LinkedMap.java
@@ -27,7 +27,6 @@ package org.openjdk.nashorn.internal.objects;
 
 import org.openjdk.nashorn.internal.runtime.Undefined;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeArray.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeArray.java
@@ -856,7 +856,7 @@ public final class NativeArray extends ScriptObject implements OptimisticBuiltin
     @SpecializedFunction(name="pop", linkLogic=PopLinkLogic.class)
     public static int popInt(final Object self) {
         //must be non empty IntArrayData
-        return getContinuousNonEmptyArrayDataCCE(self, IntElements.class).fastPopInt();
+        return getContinuousNonEmptyArrayDataCCE(self).fastPopInt();
     }
 
     /**
@@ -871,7 +871,7 @@ public final class NativeArray extends ScriptObject implements OptimisticBuiltin
     @SpecializedFunction(name="pop", linkLogic=PopLinkLogic.class)
     public static double popDouble(final Object self) {
         //must be non empty int long or double array data
-        return getContinuousNonEmptyArrayDataCCE(self, NumericElements.class).fastPopDouble();
+        return getContinuousNonEmptyArrayDataCCE(self).fastPopDouble();
     }
 
     /**
@@ -1497,7 +1497,7 @@ public final class NativeArray extends ScriptObject implements OptimisticBuiltin
     }
 
     private static boolean applyEvery(final Object self, final Object callbackfn, final Object thisArg) {
-        return new IteratorAction<Boolean>(Global.toObject(self), callbackfn, thisArg, true) {
+        return new IteratorAction<>(Global.toObject(self), callbackfn, thisArg, true) {
             private final MethodHandle everyInvoker = getEVERY_CALLBACK_INVOKER();
 
             @Override
@@ -1517,7 +1517,7 @@ public final class NativeArray extends ScriptObject implements OptimisticBuiltin
      */
     @Function(attributes = Attribute.NOT_ENUMERABLE, arity = 1)
     public static boolean some(final Object self, final Object callbackfn, final Object thisArg) {
-        return new IteratorAction<Boolean>(Global.toObject(self), callbackfn, thisArg, false) {
+        return new IteratorAction<>(Global.toObject(self), callbackfn, thisArg, false) {
             private final MethodHandle someInvoker = getSOME_CALLBACK_INVOKER();
 
             @Override
@@ -1587,7 +1587,7 @@ public final class NativeArray extends ScriptObject implements OptimisticBuiltin
      */
     @Function(attributes = Attribute.NOT_ENUMERABLE, arity = 1)
     public static NativeArray filter(final Object self, final Object callbackfn, final Object thisArg) {
-        return new IteratorAction<NativeArray>(Global.toObject(self), callbackfn, thisArg, new NativeArray()) {
+        return new IteratorAction<>(Global.toObject(self), callbackfn, thisArg, new NativeArray()) {
             private long to = 0;
             private final MethodHandle filterInvoker = getFILTER_CALLBACK_INVOKER();
 
@@ -1620,7 +1620,7 @@ public final class NativeArray extends ScriptObject implements OptimisticBuiltin
         }
 
         //if initial value is ScriptRuntime.UNDEFINED - step forward once.
-        return new IteratorAction<Object>(Global.toObject(self), callbackfn, ScriptRuntime.UNDEFINED, initialValue, iter) {
+        return new IteratorAction<>(Global.toObject(self), callbackfn, ScriptRuntime.UNDEFINED, initialValue, iter) {
             private final MethodHandle reduceInvoker = getREDUCE_CALLBACK_INVOKER();
 
             @Override
@@ -1856,10 +1856,9 @@ public final class NativeArray extends ScriptObject implements OptimisticBuiltin
     //TODO - fold these into the Link logics, but I'll do that as a later step, as I want to do a checkin
     //where everything works first
 
-    private static <T> ContinuousArrayData getContinuousNonEmptyArrayDataCCE(final Object self, final Class<T> clazz) {
+    private static ContinuousArrayData getContinuousNonEmptyArrayDataCCE(final Object self) {
         try {
-            @SuppressWarnings("unchecked")
-            final ContinuousArrayData data = (ContinuousArrayData)(T)((NativeArray)self).getArray();
+            final ContinuousArrayData data = (ContinuousArrayData) ((NativeArray)self).getArray();
             if (data.length() != 0L) {
                 return data; //if length is 0 we cannot pop and have to relink, because then we'd have to return an undefined, which is a wider type than e.g. int
            }

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeArray.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeArray.java
@@ -37,7 +37,6 @@ import static org.openjdk.nashorn.internal.runtime.linker.NashornCallSiteDescrip
 import java.lang.invoke.MethodHandle;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
@@ -1168,7 +1167,7 @@ public final class NativeArray extends ScriptObject implements OptimisticBuiltin
         final Object cmpThis = cmp == null || Bootstrap.isStrictCallable(cmp) ? ScriptRuntime.UNDEFINED : Global.instance();
 
         try {
-            Collections.sort(list, new Comparator<Object>() {
+            list.sort(new Comparator<>() {
                 private final MethodHandle call_cmp = getCALL_CMP();
                 @Override
                 public int compare(final Object x, final Object y) {

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeArray.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeArray.java
@@ -245,18 +245,17 @@ public final class NativeArray extends ScriptObject implements OptimisticBuiltin
         }
 
         // Step 3b
-        final PropertyDescriptor newLenDesc = desc;
 
         // Step 3c and 3d - get new length and convert to long
-        final long newLen = NativeArray.validLength(newLenDesc.getValue());
+        final long newLen = NativeArray.validLength(desc.getValue());
 
         // Step 3e - note that we need to convert to int or double as long is not considered a JS number type anymore
-        newLenDesc.setValue(JSType.toNarrowestNumber(newLen));
+        desc.setValue(JSType.toNarrowestNumber(newLen));
 
         // Step 3f
         // increasing array length - just need to set new length value (and attributes if any) and return
         if (newLen >= oldLen) {
-            return super.defineOwnProperty("length", newLenDesc, reject);
+            return super.defineOwnProperty("length", desc, reject);
         }
 
         // Step 3g
@@ -268,13 +267,13 @@ public final class NativeArray extends ScriptObject implements OptimisticBuiltin
         }
 
         // Step 3h and 3i
-        final boolean newWritable = !newLenDesc.has(WRITABLE) || newLenDesc.isWritable();
+        final boolean newWritable = !desc.has(WRITABLE) || desc.isWritable();
         if (!newWritable) {
-            newLenDesc.setWritable(true);
+            desc.setWritable(true);
         }
 
         // Step 3j and 3k
-        final boolean succeeded = super.defineOwnProperty("length", newLenDesc, reject);
+        final boolean succeeded = super.defineOwnProperty("length", desc, reject);
         if (!succeeded) {
             return false;
         }
@@ -286,11 +285,11 @@ public final class NativeArray extends ScriptObject implements OptimisticBuiltin
             o--;
             final boolean deleteSucceeded = delete(o, false);
             if (!deleteSucceeded) {
-                newLenDesc.setValue(o + 1);
+                desc.setValue(o + 1);
                 if (!newWritable) {
-                    newLenDesc.setWritable(false);
+                    desc.setWritable(false);
                 }
-                super.defineOwnProperty("length", newLenDesc, false);
+                super.defineOwnProperty("length", desc, false);
                 if (reject) {
                     throw typeError("property.not.writable", "length", ScriptRuntime.safeToString(this));
                 }
@@ -1048,7 +1047,7 @@ public final class NativeArray extends ScriptObject implements OptimisticBuiltin
                 } else if (!lowerExists && upperExists) {
                     sobj.set(lower, upperValue, CALLSITE_STRICT);
                     sobj.delete(upper, true);
-                } else if (lowerExists && !upperExists) {
+                } else if (lowerExists) {
                     sobj.delete(lower, true);
                     sobj.set(upper, lowerValue, CALLSITE_STRICT);
                 }

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeArray.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeArray.java
@@ -41,7 +41,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.Callable;
 import jdk.dynalink.CallSiteDescriptor;
 import jdk.dynalink.linker.GuardedInvocation;
 import jdk.dynalink.linker.LinkRequest;
@@ -180,24 +179,12 @@ public final class NativeArray extends ScriptObject implements OptimisticBuiltin
     }
 
     private static InvokeByName getJOIN() {
-        return Global.instance().getInvokeByName(JOIN,
-                new Callable<InvokeByName>() {
-                    @Override
-                    public InvokeByName call() {
-                        return new InvokeByName("join", ScriptObject.class);
-                    }
-                });
+        return Global.instance().getInvokeByName(JOIN, () -> new InvokeByName("join", ScriptObject.class));
     }
 
     private static MethodHandle createIteratorCallbackInvoker(final Object key, final Class<?> rtype) {
-        return Global.instance().getDynamicInvoker(key,
-            new Callable<MethodHandle>() {
-                @Override
-                public MethodHandle call() {
-                    return Bootstrap.createDynamicCallInvoker(rtype, Object.class, Object.class, Object.class,
-                        double.class, Object.class);
-                }
-            });
+        return Global.instance().getDynamicInvoker(key, () -> Bootstrap.createDynamicCallInvoker(rtype, Object.class, Object.class, Object.class,
+            double.class, Object.class));
     }
 
     private static MethodHandle getEVERY_CALLBACK_INVOKER() {
@@ -221,35 +208,17 @@ public final class NativeArray extends ScriptObject implements OptimisticBuiltin
     }
 
     private static MethodHandle getREDUCE_CALLBACK_INVOKER() {
-        return Global.instance().getDynamicInvoker(REDUCE_CALLBACK_INVOKER,
-                new Callable<MethodHandle>() {
-                    @Override
-                    public MethodHandle call() {
-                        return Bootstrap.createDynamicCallInvoker(Object.class, Object.class,
-                             Undefined.class, Object.class, Object.class, double.class, Object.class);
-                    }
-                });
+        return Global.instance().getDynamicInvoker(REDUCE_CALLBACK_INVOKER, () -> Bootstrap.createDynamicCallInvoker(Object.class, Object.class,
+             Undefined.class, Object.class, Object.class, double.class, Object.class));
     }
 
     private static MethodHandle getCALL_CMP() {
-        return Global.instance().getDynamicInvoker(CALL_CMP,
-                new Callable<MethodHandle>() {
-                    @Override
-                    public MethodHandle call() {
-                        return Bootstrap.createDynamicCallInvoker(double.class,
-                            Object.class, Object.class, Object.class, Object.class);
-                    }
-                });
+        return Global.instance().getDynamicInvoker(CALL_CMP, () -> Bootstrap.createDynamicCallInvoker(double.class,
+            Object.class, Object.class, Object.class, Object.class));
     }
 
     private static InvokeByName getTO_LOCALE_STRING() {
-        return Global.instance().getInvokeByName(TO_LOCALE_STRING,
-                new Callable<InvokeByName>() {
-                    @Override
-                    public InvokeByName call() {
-                        return new InvokeByName("toLocaleString", ScriptObject.class, String.class);
-                    }
-                });
+        return Global.instance().getInvokeByName(TO_LOCALE_STRING, () -> new InvokeByName("toLocaleString", ScriptObject.class, String.class));
     }
 
     // initialized by nasgen

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeDate.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeDate.java
@@ -33,7 +33,6 @@ import static org.openjdk.nashorn.internal.runtime.ECMAErrors.typeError;
 
 import java.util.Locale;
 import java.util.TimeZone;
-import java.util.concurrent.Callable;
 import org.openjdk.nashorn.internal.objects.annotations.Attribute;
 import org.openjdk.nashorn.internal.objects.annotations.Constructor;
 import org.openjdk.nashorn.internal.objects.annotations.Function;
@@ -99,12 +98,8 @@ public final class NativeDate extends ScriptObject {
 
     private static InvokeByName getTO_ISO_STRING() {
         return Global.instance().getInvokeByName(TO_ISO_STRING,
-                new Callable<InvokeByName>() {
-                    @Override
-                    public InvokeByName call() {
-                        return new InvokeByName("toISOString", ScriptObject.class, Object.class, Object.class);
-                    }
-                });
+            () -> new InvokeByName("toISOString", ScriptObject.class, Object.class, Object.class)
+        );
     }
 
     private double time;

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeDate.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeDate.java
@@ -81,16 +81,16 @@ public final class NativeDate extends ScriptObject {
     private static final double msPerHour = 3_600_000;
     private static final double msPerDay = 86_400_000;
 
-    private static int[][] firstDayInMonth = {
+    private static final int[][] firstDayInMonth = {
             {0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334}, // normal year
             {0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335}  // leap year
     };
 
-    private static String[] weekDays = {
+    private static final String[] weekDays = {
             "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
     };
 
-    private static String[] months = {
+    private static final String[] months = {
             "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
     };
 
@@ -1302,7 +1302,7 @@ public final class NativeDate extends ScriptObject {
             length = 4;
         }
         final double time = local ? nd.getLocalTime() : nd.getTime();
-        final double d[] = convertArgs(args, time, fieldId, start, length);
+        final double[] d = convertArgs(args, time, fieldId, start, length);
 
         if (! nd.isValidDate()) {
             return;

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeDebug.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeDebug.java
@@ -295,7 +295,7 @@ public final class NativeDebug extends ScriptObject {
     @Function(attributes = Attribute.NOT_ENUMERABLE, where = Where.CONSTRUCTOR)
     public static Object getEventQueueCapacity(final Object self) {
         final ScriptObject sobj = (ScriptObject)self;
-        Integer cap;
+        final int cap;
         if (sobj.has(EVENT_QUEUE_CAPACITY)) {
             cap = JSType.toInt32(sobj.get(EVENT_QUEUE_CAPACITY));
         } else {

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeJSAdapter.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeJSAdapter.java
@@ -566,15 +566,14 @@ public final class NativeJSAdapter extends ScriptObject {
              }
         }
 
-        switch (hook) {
-        case __call__:
+        if (__call__.equals(hook)) {
             throw typeError("no.such.function", NashornCallSiteDescriptor.getOperand(desc), ScriptRuntime.safeToString(this));
-        default:
-            final MethodHandle methodHandle = hook.equals(__put__) ?
-            MH.asType(Lookup.EMPTY_SETTER, type) :
-            Lookup.emptyGetter(type.returnType());
-            return new GuardedInvocation(methodHandle, testJSAdapter(adaptee, null, null, null), adaptee.getProtoSwitchPoints(hook, null), null);
         }
+
+        final MethodHandle methodHandle = hook.equals(__put__) ?
+        MH.asType(Lookup.EMPTY_SETTER, type) :
+        Lookup.emptyGetter(type.returnType());
+        return new GuardedInvocation(methodHandle, testJSAdapter(adaptee, null, null, null), adaptee.getProtoSwitchPoints(hook, null), null);
     }
 
     private static MethodHandle testJSAdapter(final Object adaptee, final MethodHandle getter, final Object where, final ScriptFunction func) {

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeJSON.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeJSON.java
@@ -311,9 +311,9 @@ public final class NativeJSON extends ScriptObject {
         if (partial.isEmpty()) {
             finalStr.append("{}");
         } else {
+            final int size = partial.size();
+            int index = 0;
             if (state.gap.isEmpty()) {
-                final int size = partial.size();
-                int       index = 0;
 
                 finalStr.append('{');
 
@@ -325,11 +325,7 @@ public final class NativeJSON extends ScriptObject {
                     index++;
                 }
 
-                finalStr.append('}');
             } else {
-                final int size  = partial.size();
-                int       index = 0;
-
                 finalStr.append("{\n");
                 finalStr.append(state.indent);
 
@@ -344,8 +340,8 @@ public final class NativeJSON extends ScriptObject {
 
                 finalStr.append('\n');
                 finalStr.append(stepback);
-                finalStr.append('}');
             }
+            finalStr.append('}');
         }
 
         state.stack.remove(value);

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeJSON.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeJSON.java
@@ -36,7 +36,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.Callable;
 import org.openjdk.nashorn.api.scripting.JSObject;
 import org.openjdk.nashorn.api.scripting.ScriptObjectMirror;
 import org.openjdk.nashorn.internal.objects.annotations.Attribute;
@@ -62,37 +61,24 @@ public final class NativeJSON extends ScriptObject {
 
     private static InvokeByName getTO_JSON() {
         return Global.instance().getInvokeByName(TO_JSON,
-                new Callable<InvokeByName>() {
-                    @Override
-                    public InvokeByName call() {
-                        return new InvokeByName("toJSON", ScriptObject.class, Object.class, Object.class);
-                    }
-                });
+            () -> new InvokeByName("toJSON", ScriptObject.class, Object.class, Object.class)
+        );
     }
 
     private static final Object JSOBJECT_INVOKER = new Object();
 
     private static MethodHandle getJSOBJECT_INVOKER() {
         return Global.instance().getDynamicInvoker(JSOBJECT_INVOKER,
-                new Callable<MethodHandle>() {
-                    @Override
-                    public MethodHandle call() {
-                        return Bootstrap.createDynamicCallInvoker(Object.class, Object.class, Object.class);
-                    }
-                });
+            () -> Bootstrap.createDynamicCallInvoker(Object.class, Object.class, Object.class)
+        );
     }
 
     private static final Object REPLACER_INVOKER = new Object();
 
     private static MethodHandle getREPLACER_INVOKER() {
         return Global.instance().getDynamicInvoker(REPLACER_INVOKER,
-                new Callable<MethodHandle>() {
-                    @Override
-                    public MethodHandle call() {
-                        return Bootstrap.createDynamicCallInvoker(Object.class,
-                            Object.class, Object.class, Object.class, Object.class);
-                    }
-                });
+            () -> Bootstrap.createDynamicCallInvoker(Object.class,Object.class, Object.class, Object.class, Object.class)
+        );
     }
 
     // initialized by nasgen

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeJSON.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeJSON.java
@@ -175,11 +175,7 @@ public final class NativeJSON extends ScriptObject {
             if (indent < 1) {
                 gap = "";
             } else {
-                final StringBuilder sb = new StringBuilder();
-                for (int i = 0; i < indent; i++) {
-                    sb.append(' ');
-                }
-                gap = sb.toString();
+                gap = " ".repeat(indent);
             }
         } else if (JSType.isString(modSpace)) {
             final String str = modSpace.toString();

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeJava.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeJava.java
@@ -476,9 +476,7 @@ public final class NativeJava {
             return props;
         } else if (object instanceof JSObject) {
             final JSObject jsObj = ((JSObject)object);
-            final ArrayList<String> props = new ArrayList<>();
-            props.addAll(jsObj.keySet());
-            return props;
+            return new ArrayList<>(jsObj.keySet());
         } else if (object != null && object != UNDEFINED) {
             // instance properties of the given object
             final Class<?> clazz = object.getClass();
@@ -493,7 +491,7 @@ public final class NativeJava {
         }
 
         // don't know about that object
-        return Collections.<String>emptyList();
+        return Collections.emptyList();
     }
 
     private static int[] copyArray(final byte[] in) {

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeRegExp.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeRegExp.java
@@ -685,7 +685,7 @@ public final class NativeRegExp extends ScriptObject {
         }
 
         int thisIndex = 0;
-        int previousLastIndex = 0;
+        int previousLastIndex;
         final StringBuilder sb = new StringBuilder();
 
         final MethodHandle invoker = function == null ? null : getReplaceValueInvoker();

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeRegExp.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeRegExp.java
@@ -32,7 +32,6 @@ import java.lang.invoke.MethodHandle;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.Callable;
 import org.openjdk.nashorn.internal.objects.annotations.Attribute;
 import org.openjdk.nashorn.internal.objects.annotations.Constructor;
 import org.openjdk.nashorn.internal.objects.annotations.Function;
@@ -799,12 +798,8 @@ public final class NativeRegExp extends ScriptObject {
 
     private static MethodHandle getReplaceValueInvoker() {
         return Global.instance().getDynamicInvoker(REPLACE_VALUE,
-                new Callable<MethodHandle>() {
-                    @Override
-                    public MethodHandle call() {
-                        return Bootstrap.createDynamicCallInvoker(String.class, Object.class, Object.class, Object[].class);
-                    }
-                });
+            () -> Bootstrap.createDynamicCallInvoker(String.class, Object.class, Object.class, Object[].class)
+        );
     }
 
     private String callReplaceValue(final MethodHandle invoker, final Object function, final Object self, final RegExpMatcher matcher, final String string) throws Throwable {

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeString.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeString.java
@@ -691,7 +691,7 @@ public final class NativeString extends ScriptObject implements OptimisticBuilti
 
         final List<Object> matches = new ArrayList<>();
 
-        Object result;
+        ScriptObject result;
         // We follow ECMAScript 6 spec here (checking for empty string instead of previous index)
         // as the ES5 specification is buggy and causes empty strings to be matched twice.
         while ((result = nativeRegExp.exec(str)) != null) {

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeString.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeString.java
@@ -284,20 +284,20 @@ public final class NativeString extends ScriptObject implements OptimisticBuilti
 
     @Override
     public boolean delete(final int key, final boolean strict) {
-        return checkDeleteIndex(key, strict)? false : super.delete(key, strict);
+        return !checkDeleteIndex(key, strict) && super.delete(key, strict);
     }
 
     @Override
     public boolean delete(final double key, final boolean strict) {
         final int index = ArrayIndex.getArrayIndex(key);
-        return checkDeleteIndex(index, strict)? false : super.delete(key, strict);
+        return !checkDeleteIndex(index, strict) && super.delete(key, strict);
     }
 
     @Override
     public boolean delete(final Object key, final boolean strict) {
         final Object primitiveKey = JSType.toPrimitive(key, String.class);
         final int index = ArrayIndex.getArrayIndex(primitiveKey);
-        return checkDeleteIndex(index, strict)? false : super.delete(primitiveKey, strict);
+        return !checkDeleteIndex(index, strict) && super.delete(primitiveKey, strict);
     }
 
     private boolean checkDeleteIndex(final int index, final boolean strict) {
@@ -971,8 +971,8 @@ public final class NativeString extends ScriptObject implements OptimisticBuilti
     public static String substring(final Object self, final int start, final int end) {
         final String str = checkObjectToString(self);
         final int len = str.length();
-        final int validStart = start < 0 ? 0 : start > len ? len : start;
-        final int validEnd   = end < 0 ? 0 : end > len ? len : end;
+        final int validStart = start < 0 ? 0 : Math.min(start, len);
+        final int validEnd   = end < 0 ? 0 : Math.min(end, len);
 
         if (validStart < validEnd) {
             return str.substring(validStart, validEnd);

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeString.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeString.java
@@ -695,7 +695,7 @@ public final class NativeString extends ScriptObject implements OptimisticBuilti
         // We follow ECMAScript 6 spec here (checking for empty string instead of previous index)
         // as the ES5 specification is buggy and causes empty strings to be matched twice.
         while ((result = nativeRegExp.exec(str)) != null) {
-            final String matchStr = JSType.toString(((ScriptObject)result).get(0));
+            final String matchStr = JSType.toString(result.get(0));
             if (matchStr.isEmpty()) {
                 nativeRegExp.setLastIndex(nativeRegExp.getLastIndex() + 1);
             }

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeSymbol.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeSymbol.java
@@ -37,7 +37,6 @@ import org.openjdk.nashorn.internal.WeakValueCache;
 import org.openjdk.nashorn.internal.objects.annotations.Attribute;
 import org.openjdk.nashorn.internal.objects.annotations.Constructor;
 import org.openjdk.nashorn.internal.objects.annotations.Function;
-import org.openjdk.nashorn.internal.objects.annotations.Getter;
 import org.openjdk.nashorn.internal.objects.annotations.Property;
 import org.openjdk.nashorn.internal.objects.annotations.ScriptClass;
 import org.openjdk.nashorn.internal.objects.annotations.Where;
@@ -66,7 +65,7 @@ public final class NativeSymbol extends ScriptObject {
     private static PropertyMap $nasgenmap$;
 
     /** See ES6 19.4.2.1 */
-    private static WeakValueCache<String, Symbol> globalSymbolRegistry = new WeakValueCache<>();
+    private static final WeakValueCache<String, Symbol> globalSymbolRegistry = new WeakValueCache<>();
 
     /**
      * ECMA 6 19.4.2.4 Symbol.iterator

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeUint32Array.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeUint32Array.java
@@ -32,7 +32,6 @@ import java.lang.invoke.MethodHandles;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.IntBuffer;
-import org.openjdk.nashorn.internal.codegen.types.Type;
 import org.openjdk.nashorn.internal.objects.annotations.Attribute;
 import org.openjdk.nashorn.internal.objects.annotations.Constructor;
 import org.openjdk.nashorn.internal.objects.annotations.Function;
@@ -42,7 +41,6 @@ import org.openjdk.nashorn.internal.objects.annotations.Where;
 import org.openjdk.nashorn.internal.runtime.JSType;
 import org.openjdk.nashorn.internal.runtime.PropertyMap;
 import org.openjdk.nashorn.internal.runtime.ScriptObject;
-import org.openjdk.nashorn.internal.runtime.UnwarrantedOptimismException;
 import org.openjdk.nashorn.internal.runtime.arrays.ArrayData;
 import org.openjdk.nashorn.internal.runtime.arrays.TypedArrayData;
 

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeWeakSet.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeWeakSet.java
@@ -126,9 +126,7 @@ public class NativeWeakSet extends ScriptObject {
 
     static void populateWeakSet(final Map<Object, Boolean> set, final Object arg, final Global global) {
         if (arg != null && arg != Undefined.getUndefined()) {
-            AbstractIterator.iterate(arg, global, value -> {
-                    set.put(checkKey(value), Boolean.TRUE);
-            });
+            AbstractIterator.iterate(arg, global, value -> set.put(checkKey(value), Boolean.TRUE));
         }
     }
 

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/parser/AbstractParser.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/parser/AbstractParser.java
@@ -199,10 +199,8 @@ public abstract class AbstractParser {
 
     /**
      * Seek next token.
-     *
-     * @return tokenType of next token.
      */
-    private TokenType nextToken() {
+    private void nextToken() {
         // Capture last token type, but ignore comments (which are irrelevant for the purpose of newline detection).
         if (type != COMMENT) {
             last = type;
@@ -229,8 +227,6 @@ public abstract class AbstractParser {
             }
 
         }
-
-        return type;
     }
 
     /**

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/parser/Lexer.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/parser/Lexer.java
@@ -651,7 +651,6 @@ public class Lexer extends Scanner {
                         reset(start);
                         return false;
                     }
-                    skip(1);
                 } else {
                     if (ch0 == '[') {
                         inBrackets = true;
@@ -660,8 +659,8 @@ public class Lexer extends Scanner {
                     }
 
                     // Skip literal character.
-                    skip(1);
                 }
+                skip(1);
             }
 
             // If regex literal.
@@ -1405,12 +1404,7 @@ public class Lexer extends Scanner {
             // Indicate that the priming first string has not been emitted.
             boolean primed = false;
 
-            while (true) {
-                // Detect end of content.
-                if (atEOF()) {
-                    break;
-                }
-
+            while (!atEOF()) {
                 // Honour escapes (should be well formed.)
                 if (ch0 == '\\' && stringType == ESCSTRING) {
                     skip(2);
@@ -1770,6 +1764,7 @@ public class Lexer extends Scanner {
             }
             return value;
         case STRING:
+        case DIRECTIVE_COMMENT:
             return source.getString(start, len); // String
         case ESCSTRING:
             return valueOfString(start, len, strict); // String
@@ -1784,8 +1779,6 @@ public class Lexer extends Scanner {
             return valueOfString(start, len, true); // String
         case XML:
             return valueOfXML(start, len); // XMLToken::LexerToken
-        case DIRECTIVE_COMMENT:
-            return source.getString(start, len);
         default:
             break;
         }

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/parser/Lexer.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/parser/Lexer.java
@@ -68,9 +68,6 @@ import org.openjdk.nashorn.internal.runtime.options.Options;
  */
 @SuppressWarnings("fallthrough")
 public class Lexer extends Scanner {
-    private static final long MIN_INT_L = Integer.MIN_VALUE;
-    private static final long MAX_INT_L = Integer.MAX_VALUE;
-
     private static final boolean XML_LITERALS = Options.getBooleanProperty("nashorn.lexer.xmlliterals");
 
     /** Content source. */

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/parser/Lexer.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/parser/Lexer.java
@@ -1746,7 +1746,7 @@ public class Lexer extends Scanner {
             return Lexer.valueOf(source.getString(start + 2, len - 2), 2); // number
         case FLOATING:
             final String str   = source.getString(start, len);
-            final double value = Double.valueOf(str);
+            final double value = Double.parseDouble(str);
             if (str.indexOf('.') != -1) {
                 return value; //number
             }

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/parser/Parser.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/parser/Parser.java
@@ -2544,7 +2544,7 @@ public class Parser extends AbstractParser implements Loggable {
         }
 
         final ParserContextLabelNode labelNode = new ParserContextLabelNode(ident.getName());
-        Block body = null;
+        final Block body;
         try {
             lc.push(labelNode);
             body = getStatement(true);

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/parser/Parser.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/parser/Parser.java
@@ -374,37 +374,33 @@ public class Parser extends AbstractParser implements Loggable {
     }
 
     /**
-     * Parse and return the list of function parameter list. A comma
+     * Parse list of function parameters. A comma
      * separated list of function parameter identifiers is expected to be parsed.
      * Errors will be thrown and the error manager will contain information
      * if parsing should fail. This method is used to check if parameter Strings
      * passed to "Function" constructor is a valid or not.
-     *
-     * @return the list of IdentNodes representing the formal parameter list
      */
-    public List<IdentNode> parseFormalParameterList() {
+    public void parseFormalParameterList() {
         try {
             stream = new TokenStream();
             lexer  = new Lexer(source, stream, scripting && !env._no_syntax_extensions, env._es6);
 
             scanFirstToken();
 
-            return formalParameterList(TokenType.EOF, false);
+            formalParameterList(TokenType.EOF, false);
         } catch (final Exception e) {
             handleParseException(e);
-            return null;
         }
     }
 
     /**
-     * Execute parse and return the resulting function node.
+     * Execute parse.
      * Errors will be thrown and the error manager will contain information
      * if parsing should fail. This method is used to check if code String
      * passed to "Function" constructor is a valid function body or not.
      *
-     * @return function node resulting from successful parse
      */
-    public FunctionNode parseFunctionBody() {
+    public void parseFunctionBody() {
         try {
             stream = new TokenStream();
             lexer  = new Lexer(source, stream, scripting && !env._no_syntax_extensions, env._es6);
@@ -445,10 +441,8 @@ public class Parser extends AbstractParser implements Loggable {
                     functionLine,
                     functionBody);
             printAST(functionNode);
-            return functionNode;
         } catch (final Exception e) {
             handleParseException(e);
-            return null;
         }
     }
 
@@ -589,8 +583,8 @@ public class Parser extends AbstractParser implements Loggable {
     /**
      * Restore the current block.
      */
-    private ParserContextBlockNode restoreBlock(final ParserContextBlockNode block) {
-        return lc.pop(block);
+    private void restoreBlock(final ParserContextBlockNode block) {
+        lc.pop(block);
     }
 
     /**

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/parser/Parser.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/parser/Parser.java
@@ -1278,7 +1278,7 @@ public class Parser extends AbstractParser implements Loggable {
                 final PropertyNode classElement = methodDefinition(isStatic, classHeritage != null, generator);
                 if (classElement.isComputed()) {
                     classElements.add(classElement);
-                } else if (!classElement.isStatic() && classElement.getKeyName().equals(CONSTRUCTOR_NAME)) {
+                } else if (!classElement.isStatic() && CONSTRUCTOR_NAME.equals(classElement.getKeyName())) {
                     if (constructor == null) {
                         constructor = classElement;
                     } else {

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/parser/Parser.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/parser/Parser.java
@@ -417,7 +417,7 @@ public class Parser extends AbstractParser implements Loggable {
             // Set up the function to append elements.
 
             final IdentNode ident = new IdentNode(functionToken, Token.descPosition(functionToken), PROGRAM.symbolName());
-            final ParserContextFunctionNode function = createParserContextFunctionNode(ident, functionToken, FunctionNode.Kind.NORMAL, functionLine, Collections.<IdentNode>emptyList());
+            final ParserContextFunctionNode function = createParserContextFunctionNode(ident, functionToken, FunctionNode.Kind.NORMAL, functionLine, Collections.emptyList());
             lc.push(function);
 
             final ParserContextBlockNode body = newBlock();
@@ -440,7 +440,7 @@ public class Parser extends AbstractParser implements Loggable {
                     function,
                     functionToken,
                     ident,
-                    Collections.<IdentNode>emptyList(),
+                    Collections.emptyList(),
                     FunctionNode.Kind.NORMAL,
                     functionLine,
                     functionBody);
@@ -833,7 +833,7 @@ public class Parser extends AbstractParser implements Loggable {
                 functionToken,
                 FunctionNode.Kind.SCRIPT,
                 functionLine,
-                Collections.<IdentNode>emptyList());
+                Collections.emptyList());
         lc.push(script);
         final ParserContextBlockNode body = newBlock();
 
@@ -850,7 +850,7 @@ public class Parser extends AbstractParser implements Loggable {
 
         expect(EOF);
 
-        return createFunctionNode(script, functionToken, ident, Collections.<IdentNode>emptyList(), FunctionNode.Kind.SCRIPT, functionLine, programBody);
+        return createFunctionNode(script, functionToken, ident, Collections.emptyList(), FunctionNode.Kind.SCRIPT, functionLine, programBody);
     }
 
     /**
@@ -3234,7 +3234,7 @@ public class Parser extends AbstractParser implements Loggable {
         expect(LPAREN);
         expect(RPAREN);
 
-        final ParserContextFunctionNode functionNode = createParserContextFunctionNode(getNameNode, getSetToken, FunctionNode.Kind.GETTER, functionLine, Collections.<IdentNode>emptyList());
+        final ParserContextFunctionNode functionNode = createParserContextFunctionNode(getNameNode, getSetToken, FunctionNode.Kind.GETTER, functionLine, Collections.emptyList());
         functionNode.setFlag(flags);
         if (computed) {
             functionNode.setFlag(FunctionNode.IS_ANONYMOUS);
@@ -3254,7 +3254,7 @@ public class Parser extends AbstractParser implements Loggable {
                 functionNode,
                 getSetToken,
                 getNameNode,
-                Collections.<IdentNode>emptyList(),
+                Collections.emptyList(),
                 FunctionNode.Kind.GETTER,
                 functionLine,
                 functionBody);
@@ -3317,7 +3317,7 @@ public class Parser extends AbstractParser implements Loggable {
 
     private PropertyFunction propertyMethodFunction(final Expression key, final long methodToken, final int methodLine, final boolean generator, final int flags, final boolean computed) {
         final String methodName = key instanceof PropertyKey ? ((PropertyKey) key).getPropertyName() : getDefaultValidFunctionName(methodLine, false);
-        final IdentNode methodNameNode = createIdentNode(((Node)key).getToken(), finish, methodName);
+        final IdentNode methodNameNode = createIdentNode(key.getToken(), finish, methodName);
 
         final FunctionNode.Kind functionKind = generator ? FunctionNode.Kind.GENERATOR : FunctionNode.Kind.NORMAL;
         final ParserContextFunctionNode functionNode = createParserContextFunctionNode(methodNameNode, methodToken, functionKind, methodLine, null);
@@ -4222,7 +4222,7 @@ public class Parser extends AbstractParser implements Loggable {
             // enforce empty bodies in nested functions that were supposed to be skipped, we do assert it as
             // an invariant in few places in the compiler pipeline, so for consistency's sake we'll throw away
             // nested bodies early if we were supposed to skip 'em.
-            body.setStatements(Collections.<Statement>emptyList());
+            body.setStatements(Collections.emptyList());
         }
 
         if (reparsedFunction != null) {
@@ -4808,7 +4808,7 @@ public class Parser extends AbstractParser implements Loggable {
             // we might have flagged has-eval in the parent function during parsing the parameter list,
             // if the parameter list contains eval; must tag arrow function as has-eval.
             for (final Statement st : parameterBlock.getStatements()) {
-                st.accept(new NodeVisitor<LexicalContext>(new LexicalContext()) {
+                st.accept(new NodeVisitor<>(new LexicalContext()) {
                     @Override
                     public boolean enterCallNode(final CallNode callNode) {
                         if (callNode.getFunction() instanceof IdentNode && ((IdentNode) callNode.getFunction()).getName().equals("eval")) {
@@ -5131,7 +5131,7 @@ public class Parser extends AbstractParser implements Loggable {
                             functionToken,
                             FunctionNode.Kind.MODULE,
                             functionLine,
-                            Collections.<IdentNode>emptyList());
+                            Collections.emptyList());
             lc.push(script);
 
             final ParserContextModuleNode module = new ParserContextModuleNode(moduleName);
@@ -5154,7 +5154,7 @@ public class Parser extends AbstractParser implements Loggable {
             expect(EOF);
 
             script.setModule(module.createModule());
-            return createFunctionNode(script, functionToken, ident, Collections.<IdentNode>emptyList(), FunctionNode.Kind.MODULE, functionLine, programBody);
+            return createFunctionNode(script, functionToken, ident, Collections.emptyList(), FunctionNode.Kind.MODULE, functionLine, programBody);
         } finally {
             isStrictMode = oldStrictMode;
         }

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/parser/Parser.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/parser/Parser.java
@@ -3726,18 +3726,7 @@ public class Parser extends AbstractParser implements Loggable {
     }
 
     private static <T> List<T> optimizeList(final ArrayList<T> list) {
-        switch(list.size()) {
-            case 0: {
-                return Collections.emptyList();
-            }
-            case 1: {
-                return Collections.singletonList(list.get(0));
-            }
-            default: {
-                list.trimToSize();
-                return list;
-            }
-        }
+        return List.copyOf(list);
     }
 
     /**

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/parser/ParserContext.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/parser/ParserContext.java
@@ -287,7 +287,7 @@ class ParserContext {
         private int index;
         private T next;
         private final Class<T> clazz;
-        private ParserContextNode until;
+        private final ParserContextNode until;
 
         NodeIterator(final Class<T> clazz) {
             this(clazz, null);

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/parser/ParserContextFunctionNode.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/parser/ParserContextFunctionNode.java
@@ -259,7 +259,7 @@ class ParserContextFunctionNode extends ParserContextBaseNode {
         return getFlag(FunctionNode.ES6_IS_SUBCLASS_CONSTRUCTOR) != 0;
     }
 
-    boolean addParameterBinding(final IdentNode bindingIdentifier) {
+    void addParameterBinding(final IdentNode bindingIdentifier) {
         if (Parser.isArguments(bindingIdentifier)) {
             setFlag(FunctionNode.DEFINES_ARGUMENTS);
         }
@@ -267,11 +267,8 @@ class ParserContextFunctionNode extends ParserContextBaseNode {
         if (parameterBoundNames == null) {
             parameterBoundNames = new HashSet<>();
         }
-        if (parameterBoundNames.add(bindingIdentifier.getName())) {
-            return true;
-        } else {
+        if (!parameterBoundNames.add(bindingIdentifier.getName())) {
             duplicateParameterBinding = bindingIdentifier;
-            return false;
         }
     }
 

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/parser/Scanner.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/parser/Scanner.java
@@ -172,7 +172,7 @@ public class Scanner {
         ch1 = charAt(i + 1);
         ch2 = charAt(i + 2);
         ch3 = charAt(i + 3);
-        position = i < limit? i : limit;
+        position = Math.min(i, limit);
     }
 
     /**

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/parser/TokenType.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/parser/TokenType.java
@@ -40,7 +40,6 @@ import java.util.Locale;
 /**
  * Description of all the JavaScript tokens.
  */
-@SuppressWarnings("javadoc")
 public enum TokenType {
     ERROR                (SPECIAL,  null),
     EOF                  (SPECIAL,  null),

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/AccessorProperty.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/AccessorProperty.java
@@ -40,7 +40,6 @@ import java.io.ObjectInputStream;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.SwitchPoint;
-import java.util.function.Supplier;
 import java.util.logging.Level;
 import org.openjdk.nashorn.internal.codegen.ObjectClassGenerator;
 import org.openjdk.nashorn.internal.codegen.types.Type;
@@ -66,7 +65,7 @@ public class AccessorProperty extends Property {
      * these are the most frequently retrieved ones, and lookup of method handle natives only registers in the profiler
      * for them.
      */
-    private static ClassValue<Accessors> GETTERS_SETTERS = new ClassValue<Accessors>() {
+    private static final ClassValue<Accessors> GETTERS_SETTERS = new ClassValue<>() {
         @Override
         protected Accessors computeValue(final Class<?> structure) {
             return new Accessors(structure);
@@ -664,12 +663,7 @@ public class AccessorProperty extends Property {
                 mh,
                 0,
                 true,
-                new Supplier<String>() {
-                    @Override
-                    public String get() {
-                        return tag + " '" + getKey() + "' (property="+ Debug.id(this) + ", slot=" + getSlot() + " " + getClass().getSimpleName() + " forType=" + stripName(forType) + ", type=" + stripName(type) + ')';
-                    }
-                });
+                () -> tag + " '" + getKey() + "' (property="+ Debug.id(this) + ", slot=" + getSlot() + " " + getClass().getSimpleName() + " forType=" + stripName(forType) + ", type=" + stripName(type) + ')');
     }
 
     private MethodHandle debugReplace(final Class<?> oldType, final Class<?> newType, final PropertyMap oldMap, final PropertyMap newMap) {
@@ -683,12 +677,7 @@ public class AccessorProperty extends Property {
         MethodHandle mh = context.addLoggingToHandle(
                 ObjectClassGenerator.class,
                 REPLACE_MAP,
-                new Supplier<String>() {
-                    @Override
-                    public String get() {
-                        return "Type change for '" + getKey() + "' " + oldType + "=>" + newType;
-                    }
-                });
+                () -> "Type change for '" + getKey() + "' " + oldType + "=>" + newType);
 
         mh = context.addLoggingToHandle(
                 ObjectClassGenerator.class,
@@ -696,12 +685,7 @@ public class AccessorProperty extends Property {
                 mh,
                 Integer.MAX_VALUE,
                 false,
-                new Supplier<String>() {
-                    @Override
-                    public String get() {
-                        return "Setting map " + Debug.id(oldMap) + " => " + Debug.id(newMap) + " " + oldMap + " => " + newMap;
-                    }
-                });
+                () -> "Setting map " + Debug.id(oldMap) + " => " + Debug.id(newMap) + " " + oldMap + " => " + newMap);
         return mh;
     }
 
@@ -716,12 +700,7 @@ public class AccessorProperty extends Property {
         return context.addLoggingToHandle(
                 ObjectClassGenerator.class,
                 invalidator,
-                new Supplier<String>() {
-                    @Override
-                    public String get() {
-                        return "Field change callback for " + key + " triggered ";
-                    }
-                });
+                () -> "Field change callback for " + key + " triggered ");
     }
 
     private static MethodHandle findOwnMH_S(final String name, final Class<?> rtype, final Class<?>... types) {

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/AstDeserializer.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/AstDeserializer.java
@@ -38,16 +38,13 @@ import org.openjdk.nashorn.internal.ir.FunctionNode;
  */
 final class AstDeserializer {
     static FunctionNode deserialize(final byte[] serializedAst) {
-        return AccessController.doPrivileged(new PrivilegedAction<FunctionNode>() {
-            @Override
-            public FunctionNode run() {
-                try {
-                    return (FunctionNode)new ObjectInputStream(new InflaterInputStream(
-                        new ByteArrayInputStream(serializedAst))).readObject();
-                } catch (final ClassNotFoundException | IOException e) {
-                    // This is internal, can't happen
-                    throw new AssertionError("Unexpected exception deserializing function", e);
-                }
+        return AccessController.doPrivileged((PrivilegedAction<FunctionNode>) () -> {
+            try {
+                return (FunctionNode)new ObjectInputStream(new InflaterInputStream(
+                    new ByteArrayInputStream(serializedAst))).readObject();
+            } catch (final ClassNotFoundException | IOException e) {
+                // This is internal, can't happen
+                throw new AssertionError("Unexpected exception deserializing function", e);
             }
         });
     }

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/CommandExecutor.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/CommandExecutor.java
@@ -43,6 +43,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import static org.openjdk.nashorn.internal.runtime.CommandExecutor.RedirectType.*;
@@ -502,7 +503,7 @@ class CommandExecutor {
      *         processed by the underlying platform
      */
     private static String sanitizePath(final String d) {
-        if (!IS_WINDOWS || (IS_WINDOWS && !d.startsWith(CYGDRIVE))) {
+        if (!IS_WINDOWS || !d.startsWith(CYGDRIVE)) {
             return d;
         }
         final String pd = d.substring(CYGDRIVE.length());
@@ -629,13 +630,11 @@ class CommandExecutor {
         // If input is not redirected.
         if (inputIsPipe) {
             // If inputStream other than System.in is provided.
-            if (inputStream != null) {
-                // Pipe inputStream to first process output stream.
-                piperThreads.add(new Piper(inputStream, firstProcess.getOutputStream()).start());
-            } else {
-                // Otherwise assume an input string has been provided.
-                piperThreads.add(new Piper(new ByteArrayInputStream(inputString.getBytes()), firstProcess.getOutputStream()).start());
-            }
+            // Pipe inputStream to first process output stream.
+            // Otherwise assume an input string has been provided.
+            piperThreads.add(new Piper(Objects
+                .requireNonNullElseGet(inputStream, () -> new ByteArrayInputStream(inputString
+                    .getBytes())), firstProcess.getOutputStream()).start());
         }
 
         // If output is not redirected.

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/CommandExecutor.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/CommandExecutor.java
@@ -60,18 +60,14 @@ class CommandExecutor {
 
     // Test to see if running on Windows.
     private static final boolean IS_WINDOWS =
-        AccessController.doPrivileged((PrivilegedAction<Boolean>)() -> {
-        return System.getProperty("os.name").contains("Windows");
-    });
+        AccessController.doPrivileged((PrivilegedAction<Boolean>)() -> System.getProperty("os.name").contains("Windows"));
 
     // Cygwin drive alias prefix.
     private static final String CYGDRIVE = "/cygdrive/";
 
     // User's home directory
     private static final String HOME_DIRECTORY =
-        AccessController.doPrivileged((PrivilegedAction<String>)() -> {
-        return System.getProperty("user.home");
-    });
+        AccessController.doPrivileged((PrivilegedAction<String>)() -> System.getProperty("user.home"));
 
     // Various types of standard redirects.
     enum RedirectType {
@@ -83,7 +79,7 @@ class CommandExecutor {
         REDIRECT_ERROR_APPEND,
         REDIRECT_OUTPUT_ERROR_APPEND,
         REDIRECT_ERROR_TO_OUTPUT
-    };
+    }
 
     // Prefix strings to standard redirects.
     private static final String[] redirectPrefixes = new String[] {
@@ -329,7 +325,7 @@ class CommandExecutor {
     private OutputStream errorStream;
 
     // Ordered collection of current or piped ProcessBuilders.
-    private List<ProcessBuilder> processBuilders = new ArrayList<>();
+    private final List<ProcessBuilder> processBuilders = new ArrayList<>();
 
     CommandExecutor() {
         this.environment = new HashMap<>();
@@ -340,7 +336,6 @@ class CommandExecutor {
         this.inputStream = null;
         this.outputStream = null;
         this.errorStream = null;
-        this.processBuilders = new ArrayList<>();
     }
 
     /**
@@ -386,7 +381,7 @@ class CommandExecutor {
      */
     private static String stripQuotes(String token) {
         if ((token.startsWith("\"") && token.endsWith("\"")) ||
-             token.startsWith("\'") && token.endsWith("\'")) {
+             token.startsWith("'") && token.endsWith("'")) {
             token = token.substring(1, token.length() - 1);
         }
         return token;
@@ -785,7 +780,7 @@ class CommandExecutor {
                     command.clear();
                 } else if (token.endsWith("\\")) {
                     // Backslash followed by space.
-                    sb.append(token.substring(0, token.length() - 1)).append(' ');
+                    sb.append(token, 0, token.length() - 1).append(' ');
                 } else if (sb.length() == 0) {
                     // If not a word then must be a quoted string.
                     if (tokenizer.ttype != StreamTokenizer.TT_WORD) {

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/CommandExecutor.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/CommandExecutor.java
@@ -698,7 +698,7 @@ class CommandExecutor {
             errorString += byteErrorStream != null ? byteErrorStream.toString() : "";
         } catch (final InterruptedException ex) {
             // Kill any living processes.
-            processes.stream().forEach(p -> {
+            processes.forEach(p -> {
                 if (p.isAlive()) {
                     p.destroy();
                 }

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/CompiledFunction.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/CompiledFunction.java
@@ -758,15 +758,7 @@ final class CompiledFunction {
                 break;
             }
 
-            final StringBuilder sb = new StringBuilder();
-            sb.append('[').
-                    append("program point: ").
-                    append(entry.getKey()).
-                    append(" -> ").
-                    append(type).
-                    append(']');
-
-            list.add(sb.toString());
+            list.add('[' + "program point: " + entry.getKey() + " -> " + type + ']');
         }
 
         return list;

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/CompiledFunction.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/CompiledFunction.java
@@ -643,12 +643,7 @@ final class CompiledFunction {
     }
 
     private static void relinkComposableInvoker(final CallSite cs, final CompiledFunction inv, final boolean constructor) {
-        final HandleAndAssumptions handleAndAssumptions = inv.getValidOptimisticInvocation(new Supplier<MethodHandle>() {
-            @Override
-            public MethodHandle get() {
-                return inv.getInvokerOrConstructor(constructor);
-            }
-        });
+        final HandleAndAssumptions handleAndAssumptions = inv.getValidOptimisticInvocation(() -> inv.getInvokerOrConstructor(constructor));
         final MethodHandle handle = handleAndAssumptions.handle;
         final SwitchPoint assumptions = handleAndAssumptions.assumptions;
         final MethodHandle target;
@@ -674,12 +669,7 @@ final class CompiledFunction {
      * @return a guarded invocation for an ordinary (non-constructor) invocation of this function.
      */
     GuardedInvocation createFunctionInvocation(final Class<?> callSiteReturnType, final int callerProgramPoint) {
-        return getValidOptimisticInvocation(new Supplier<MethodHandle>() {
-            @Override
-            public MethodHandle get() {
-                return createInvoker(callSiteReturnType, callerProgramPoint);
-            }
-        }).createInvocation();
+        return getValidOptimisticInvocation(() -> createInvoker(callSiteReturnType, callerProgramPoint)).createInvocation();
     }
 
     /**
@@ -691,12 +681,7 @@ final class CompiledFunction {
      * @return a guarded invocation for invocation of this function as a constructor.
      */
     GuardedInvocation createConstructorInvocation() {
-        return getValidOptimisticInvocation(new Supplier<MethodHandle>() {
-            @Override
-            public MethodHandle get() {
-                return getConstructor();
-            }
-        }).createInvocation();
+        return getValidOptimisticInvocation(this::getConstructor).createInvocation();
     }
 
     private MethodHandle createInvoker(final Class<?> callSiteReturnType, final int callerProgramPoint) {

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/CompiledFunction.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/CompiledFunction.java
@@ -37,7 +37,6 @@ import java.lang.invoke.SwitchPoint;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -737,8 +736,7 @@ final class CompiledFunction {
 
         final List<String> list = new ArrayList<>();
 
-        for (final Iterator<Map.Entry<Integer, Type>> iter = ipp.entrySet().iterator(); iter.hasNext(); ) {
-            final Map.Entry<Integer, Type> entry = iter.next();
+        for (final Map.Entry<Integer, Type> entry : ipp.entrySet()) {
             final char bct = entry.getValue().getBytecodeStackType();
             final String type;
 

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/Context.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/Context.java
@@ -594,7 +594,7 @@ public final class Context {
      * @param appLoader application class loader
      */
     public Context(final Options options, final ErrorManager errors, final PrintWriter out, final PrintWriter err, final ClassLoader appLoader) {
-        this(options, errors, out, err, appLoader, (ClassFilter)null);
+        this(options, errors, out, err, appLoader, null);
     }
 
     /**

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/Context.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/Context.java
@@ -67,7 +67,6 @@ import java.security.PrivilegedExceptionAction;
 import java.security.ProtectionDomain;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/Context.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/Context.java
@@ -627,7 +627,7 @@ public final class Context {
         // if user passed --module-path, we create a module class loader with
         // passed appLoader as the parent.
         final String modulePath = env._module_path;
-        ClassLoader appCl = null;
+        ClassLoader appCl;
         if (!env._compile_only && modulePath != null && !modulePath.isEmpty()) {
             // make sure that caller can create a class loader.
             if (sm != null) {
@@ -780,7 +780,7 @@ public final class Context {
      * @return reusable compiled script across many global scopes.
      */
     public MultiGlobalCompiledScript compileScript(final Source source) {
-        final Class<?> clazz = compile(source, this.errors, this._strict, false);
+        final Class<?> clazz = compile(source, this.errors, this._strict);
         final MethodHandle createProgramFunctionHandle = getCreateProgramFunctionHandle(clazz);
 
         return newGlobal -> invokeCreateProgramFunctionHandle(createProgramFunctionHandle, newGlobal);
@@ -829,7 +829,7 @@ public final class Context {
 
         Class<?> clazz;
         try {
-            clazz = compile(source, new ThrowErrorManager(), strictFlag, true);
+            clazz = compile(source, new ThrowErrorManager(), strictFlag);
         } catch (final ParserException e) {
             e.throwAsEcmaException(global);
             return null;
@@ -1103,7 +1103,7 @@ public final class Context {
      *
      * @param sm current security manager instance
      * @param fullName fully qualified package name
-     * @throw SecurityException if not accessible
+     * @throws SecurityException if not accessible
      */
     private static void checkPackageAccess(final SecurityManager sm, final String fullName) {
         Objects.requireNonNull(sm);
@@ -1446,10 +1446,10 @@ public final class Context {
     }
 
     private ScriptFunction compileScript(final Source source, final ScriptObject scope, final ErrorManager errMan) {
-        return getProgramFunction(compile(source, errMan, this._strict, false), scope);
+        return getProgramFunction(compile(source, errMan, this._strict), scope);
     }
 
-    private synchronized Class<?> compile(final Source source, final ErrorManager errMan, final boolean strict, final boolean isEval) {
+    private synchronized Class<?> compile(final Source source, final ErrorManager errMan, final boolean strict) {
         // start with no errors, no warnings.
         errMan.reset();
 

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/DebuggerSupport.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/DebuggerSupport.java
@@ -350,7 +350,7 @@ final class DebuggerSupport {
                 sb.append("\\\"");
                 break;
             case '\'':
-                sb.append("\\\'");
+                sb.append("\\'");
                 break;
             case '\b':
                 sb.append("\\b");

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ECMAErrors.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ECMAErrors.java
@@ -82,25 +82,24 @@ public final class ECMAErrors {
         final JSErrorType errorType = e.getErrorType();
         assert errorType != null : "error type for " + e + " was null";
 
-        final Global globalObj    = global;
         final String       msg    = e.getMessage();
 
         // translate to ECMAScript Error object using error type
         switch (errorType) {
         case ERROR:
-            return error(globalObj.newError(msg), e);
+            return error(global.newError(msg), e);
         case EVAL_ERROR:
-            return error(globalObj.newEvalError(msg), e);
+            return error(global.newEvalError(msg), e);
         case RANGE_ERROR:
-            return error(globalObj.newRangeError(msg), e);
+            return error(global.newRangeError(msg), e);
         case REFERENCE_ERROR:
-            return error(globalObj.newReferenceError(msg), e);
+            return error(global.newReferenceError(msg), e);
         case SYNTAX_ERROR:
-            return error(globalObj.newSyntaxError(msg), e);
+            return error(global.newSyntaxError(msg), e);
         case TYPE_ERROR:
-            return error(globalObj.newTypeError(msg), e);
+            return error(global.newTypeError(msg), e);
         case URI_ERROR:
-            return error(globalObj.newURIError(msg), e);
+            return error(global.newURIError(msg), e);
         default:
             // should not happen - perhaps unknown error type?
             throw new AssertionError(e.getMessage());

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/FinalScriptFunctionData.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/FinalScriptFunctionData.java
@@ -149,7 +149,7 @@ final class FinalScriptFunctionData extends ScriptFunctionData {
         return MethodType.genericMethodType(max + 1);
     }
 
-    private CompiledFunction addInvoker(final MethodHandle mh, final Specialization specialization) {
+    private void addInvoker(final MethodHandle mh, final Specialization specialization) {
         assert !needsCallee(mh);
 
         final CompiledFunction invoker;
@@ -162,12 +162,10 @@ final class FinalScriptFunctionData extends ScriptFunctionData {
             invoker = new CompiledFunction(mh, null, specialization);
         }
         code.add(invoker);
-
-        return invoker;
     }
 
-    private CompiledFunction addInvoker(final MethodHandle mh) {
-        return addInvoker(mh, null);
+    private void addInvoker(final MethodHandle mh) {
+        addInvoker(mh, null);
     }
 
     private static int methodHandleArity(final MethodHandle mh) {

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/GlobalFunctions.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/GlobalFunctions.java
@@ -450,20 +450,18 @@ loop:
         final StringBuilder sb = new StringBuilder();
         for (int k = 0; k < length; k++) {
             char ch = str.charAt(k);
-            if (ch != '%') {
-                sb.append(ch);
-            } else {
+            if (ch == '%') {
                 if (k < (length - 5)) {
-                   if (str.charAt(k + 1) == 'u') {
-                       try {
-                           ch = (char) Integer.parseInt(str.substring(k + 2, k + 6), 16);
-                           sb.append(ch);
-                           k += 5;
-                           continue;
-                       } catch (final NumberFormatException e) {
-                           //ignored
-                       }
-                   }
+                    if (str.charAt(k + 1) == 'u') {
+                        try {
+                            ch = (char) Integer.parseInt(str.substring(k + 2, k + 6), 16);
+                            sb.append(ch);
+                            k += 5;
+                            continue;
+                        } catch (final NumberFormatException e) {
+                            //ignored
+                        }
+                    }
                 }
 
                 if (k < (length - 2)) {
@@ -478,8 +476,8 @@ loop:
                 }
 
                 // everything fails
-                sb.append(ch);
             }
+            sb.append(ch);
         }
 
         return sb.toString();

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/GlobalFunctions.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/GlobalFunctions.java
@@ -311,7 +311,7 @@ loop:
         }
 
         try {
-            final double result = Double.valueOf(str.substring(start, end));
+            final double result = Double.parseDouble(str.substring(start, end));
             return negative ? -result : result;
         } catch (final NumberFormatException e) {
             return Double.NaN;

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/JSONFunctions.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/JSONFunctions.java
@@ -26,7 +26,6 @@
 package org.openjdk.nashorn.internal.runtime;
 
 import java.lang.invoke.MethodHandle;
-import java.util.concurrent.Callable;
 import org.openjdk.nashorn.internal.objects.Global;
 import org.openjdk.nashorn.internal.parser.JSONParser;
 import org.openjdk.nashorn.internal.runtime.arrays.ArrayIndex;
@@ -41,14 +40,8 @@ public final class JSONFunctions {
     private static final Object REVIVER_INVOKER = new Object();
 
     private static MethodHandle getREVIVER_INVOKER() {
-        return Context.getGlobal().getDynamicInvoker(REVIVER_INVOKER,
-                new Callable<MethodHandle>() {
-                    @Override
-                    public MethodHandle call() {
-                        return Bootstrap.createDynamicCallInvoker(Object.class,
-                            Object.class, Object.class, String.class, Object.class);
-                    }
-                });
+        return Context.getGlobal().getDynamicInvoker(REVIVER_INVOKER, () -> Bootstrap.createDynamicCallInvoker(Object.class,
+            Object.class, Object.class, String.class, Object.class));
     }
 
     /**

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/JSType.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/JSType.java
@@ -811,9 +811,9 @@ public enum JSType {
      */
     public static Number toNarrowestNumber(final long l) {
         if (isRepresentableAsInt(l)) {
-            return Integer.valueOf((int) l);
+            return (int) l;
         } else {
-            return Double.valueOf(l);
+            return (double) l;
         }
     }
 

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/JSType.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/JSType.java
@@ -32,8 +32,6 @@ import static org.openjdk.nashorn.internal.runtime.ECMAErrors.typeError;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Array;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import jdk.dynalink.SecureLookupSupplier;
 import jdk.dynalink.beans.StaticClass;
@@ -195,11 +193,7 @@ public enum JSType {
      * The list of available accessor types in width order. This order is used for type guesses narrow{@literal ->} wide
      *  in the dual--fields world
      */
-    private static final List<Type> ACCESSOR_TYPES = Collections.unmodifiableList(
-            Arrays.asList(
-                Type.INT,
-                Type.NUMBER,
-                Type.OBJECT));
+    private static final List<Type> ACCESSOR_TYPES = List.of(Type.INT, Type.NUMBER, Type.OBJECT);
 
     /** table index for undefined type - hard coded so it can be used in switches at compile time */
     public static final int TYPE_UNDEFINED_INDEX = -1;
@@ -211,20 +205,18 @@ public enum JSType {
     public static final int TYPE_OBJECT_INDEX = 2; //getAccessorTypeIndex(Object.class);
 
     /** object conversion quickies with JS semantics - used for return value and parameter filter */
-    public static final List<MethodHandle> CONVERT_OBJECT = toUnmodifiableList(
+    public static final List<MethodHandle> CONVERT_OBJECT = List.of(
         JSType.TO_INT32.methodHandle(),
-        JSType.TO_NUMBER.methodHandle(),
-        null
+        JSType.TO_NUMBER.methodHandle()
     );
 
     /**
      * object conversion quickies with JS semantics - used for return value and parameter filter, optimistic
      * throws exception upon incompatible type (asking for a narrower one than the storage)
      */
-    public static final List<MethodHandle> CONVERT_OBJECT_OPTIMISTIC = toUnmodifiableList(
+    public static final List<MethodHandle> CONVERT_OBJECT_OPTIMISTIC = List.of(
         JSType.TO_INT32_OPTIMISTIC.methodHandle(),
-        JSType.TO_NUMBER_OPTIMISTIC.methodHandle(),
-        null
+        JSType.TO_NUMBER_OPTIMISTIC.methodHandle()
     );
 
     /** The value of Undefined cast to an int32 */
@@ -242,7 +234,7 @@ public enum JSType {
      * Method handles for getters that return undefined coerced
      * to the appropriate type
      */
-    public static final List<MethodHandle> GET_UNDEFINED = toUnmodifiableList(
+    public static final List<MethodHandle> GET_UNDEFINED = List.of(
         MH.constant(int.class, UNDEFINED_INT),
         MH.constant(double.class, UNDEFINED_DOUBLE),
         MH.constant(Object.class, Undefined.getUndefined())
@@ -1805,9 +1797,5 @@ public enum JSType {
         } else {
             return Object.class;
         }
-    }
-
-    private static List<MethodHandle> toUnmodifiableList(final MethodHandle... methodHandles) {
-        return Collections.unmodifiableList(Arrays.asList(methodHandles));
     }
 }

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/JSType.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/JSType.java
@@ -475,7 +475,7 @@ public enum JSType {
             return toPrimitive((JSObject)obj, hint);
         } else if (obj instanceof StaticClass) {
             final String name = ((StaticClass)obj).getRepresentedClass().getName();
-            return new StringBuilder(12 + name.length()).append("[JavaClass ").append(name).append(']').toString();
+            return "[JavaClass " + name + ']';
         }
         return obj.toString();
     }

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/JSType.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/JSType.java
@@ -1700,7 +1700,7 @@ public enum JSType {
         return ACCESSOR_TYPES.size();
     }
 
-    private static double parseRadix(final char chars[], final int start, final int length, final int radix) {
+    private static double parseRadix(final char[] chars, final int start, final int length, final int radix) {
         int pos = 0;
 
         for (int i = start; i < length ; i++) {

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ListAdapter.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ListAdapter.java
@@ -358,7 +358,7 @@ public class ListAdapter extends AbstractList<Object> implements RandomAccess, D
     @Override
     public final Iterator<Object> descendingIterator() {
         final ListIterator<Object> it = listIterator(size());
-        return new Iterator<Object>() {
+        return new Iterator<>() {
             @Override
             public boolean hasNext() {
                 return it.hasPrevious();

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ListAdapter.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ListAdapter.java
@@ -397,12 +397,7 @@ public class ListAdapter extends AbstractList<Object> implements RandomAccess, D
     }
 
     private static Callable<MethodHandle> invokerCreator(final Class<?> rtype, final Class<?>... ptypes) {
-        return new Callable<MethodHandle>() {
-            @Override
-            public MethodHandle call() {
-                return Bootstrap.createDynamicCallInvoker(rtype, ptypes);
-            }
-        };
+        return () -> Bootstrap.createDynamicCallInvoker(rtype, ptypes);
     }
 
     private MethodHandle getDynamicInvoker(final Object key, final Callable<MethodHandle> creator) {

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/NashornLoader.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/NashornLoader.java
@@ -41,6 +41,7 @@ import java.security.PermissionCollection;
 import java.security.PrivilegedAction;
 import java.security.Permissions;
 import java.security.SecureClassLoader;
+import java.util.Arrays;
 
 /**
  * Superclass for Nashorn class loader classes.
@@ -170,20 +171,10 @@ abstract class NashornLoader extends SecureClassLoader {
      */
     private static URL[] pathToURLs(final String path) {
         final String[] components = path.split(File.pathSeparator);
-        URL[] urls = new URL[components.length];
-        int count = 0;
-        while(count < components.length) {
-            final URL url = fileToURL(new File(components[count]));
-            if (url != null) {
-                urls[count++] = url;
-            }
-        }
-        if (urls.length != count) {
-            final URL[] tmp = new URL[count];
-            System.arraycopy(urls, 0, tmp, 0, count);
-            urls = tmp;
-        }
-        return urls;
+        return Arrays.stream(components)
+            .map(File::new)
+            .map(NashornLoader::fileToURL)
+            .toArray(URL[]::new);
     }
 
     /*

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/NashornLoader.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/NashornLoader.java
@@ -52,11 +52,6 @@ abstract class NashornLoader extends SecureClassLoader {
     protected static final String RUNTIME_ARRAYS_PKG = "org.openjdk.nashorn.internal.runtime.arrays";
     protected static final String RUNTIME_LINKER_PKG = "org.openjdk.nashorn.internal.runtime.linker";
     protected static final String SCRIPTS_PKG        = "org.openjdk.nashorn.internal.scripts";
-    protected static final String OBJECTS_PKG_INTERNAL        = "org/openjdk/nashorn/internal/objects";
-    protected static final String RUNTIME_PKG_INTERNAL        = "org/openjdk/nashorn/internal/runtime";
-    protected static final String RUNTIME_ARRAYS_PKG_INTERNAL = "org/openjdk/nashorn/internal/runtime/arrays";
-    protected static final String RUNTIME_LINKER_PKG_INTERNAL = "org/openjdk/nashorn/internal/runtime/linker";
-    protected static final String SCRIPTS_PKG_INTERNAL        = "org/openjdk/nashorn/internal/scripts";
 
     static final Module NASHORN_MODULE = Context.class.getModule();
 

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/Property.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/Property.java
@@ -605,12 +605,7 @@ public abstract class Property implements Serializable {
     }
 
     private static String indent(final String str, final int indent) {
-        final StringBuilder sb = new StringBuilder();
-        sb.append(str);
-        for (int i = 0; i < indent - str.length(); i++) {
-            sb.append(' ');
-        }
-        return sb.toString();
+        return str + " ".repeat(Math.max(0, indent - str.length()));
      }
 
     @Override

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/PropertyHashMap.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/PropertyHashMap.java
@@ -137,7 +137,7 @@ public final class PropertyHashMap implements Map <Object, Property> {
     private final Element list;
 
     /** Hash map bins. */
-    private Element[] bins;
+    private final Element[] bins;
 
     /** Queue for adding elements to large maps with delayed hashing. */
     private ElementQueue queue;

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/PropertyHashMap.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/PropertyHashMap.java
@@ -25,7 +25,6 @@
 
 package org.openjdk.nashorn.internal.runtime;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/PropertyHashMap.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/PropertyHashMap.java
@@ -617,7 +617,7 @@ public final class PropertyHashMap implements Map <Object, Property> {
 
         @Override
         public String toString() {
-            final StringBuffer sb = new StringBuffer();
+            final StringBuilder sb = new StringBuilder();
 
             sb.append('[');
 
@@ -816,7 +816,7 @@ public final class PropertyHashMap implements Map <Object, Property> {
             if (bins != null) {
                 final int binIndex = binIndex(bins, key);
                 final Element bin = bins[binIndex];
-                if (findElement(bin, key) != null) { ;
+                if (findElement(bin, key) != null) {
                     if (size >= LIST_THRESHOLD) {
                         ensureOwnBins();
                         bins[binIndex] = removeFromList(bin, key);

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/PropertyHashMap.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/PropertyHashMap.java
@@ -522,7 +522,7 @@ public final class PropertyHashMap implements Map <Object, Property> {
     }
 
     @Override
-    public void putAll(final Map<? extends Object, ? extends Property> m) {
+    public void putAll(final Map<?, ? extends Property> m) {
         throw new UnsupportedOperationException("Immutable map.");
     }
 

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/PropertyHashMap.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/PropertyHashMap.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.openjdk.nashorn.internal.runtime.options.Options;
@@ -541,7 +542,7 @@ public final class PropertyHashMap implements Map <Object, Property> {
 
     @Override
     public Collection<Property> values() {
-        return Collections.unmodifiableList(Arrays.asList(getProperties()));
+        return List.of(getProperties());
     }
 
     @Override

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/PropertyMap.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/PropertyMap.java
@@ -474,7 +474,7 @@ public class PropertyMap implements Iterable<Object>, Serializable {
         assert sameType ||
                 oldProperty instanceof AccessorProperty &&
                 newProperty instanceof UserAccessorProperty :
-            "arbitrary replaceProperty attempted " + sameType + " oldProperty=" + oldProperty.getClass() + " newProperty=" + newProperty.getClass() + " [" + oldProperty.getLocalType() + " => " + newProperty.getLocalType() + "]";
+            "arbitrary replaceProperty attempted oldProperty=" + oldProperty.getClass() + " newProperty=" + newProperty.getClass() + " [" + oldProperty.getLocalType() + " => " + newProperty.getLocalType() + "]";
 
         /*
          * spillLength remains same in case (1) and (2) because of slot reuse. Only for case (3), we need

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/QuotedStringTokenizer.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/QuotedStringTokenizer.java
@@ -37,7 +37,7 @@ import java.util.StringTokenizer;
 public final class QuotedStringTokenizer {
     private final LinkedList<String> tokens;
 
-    private final char quotes[];
+    private final char[] quotes;
 
     /**
      * Constructor

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/RecompilableScriptFunctionData.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/RecompilableScriptFunctionData.java
@@ -698,7 +698,7 @@ public final class RecompilableScriptFunctionData extends ScriptFunctionData imp
             return invalidatedProgramPoints;
         }
         final Map<Integer, Type> loadedProgramPoints = OptimisticTypesPersistence.load(typeInformationFile);
-        return loadedProgramPoints != null ? loadedProgramPoints : new TreeMap<Integer, Type>();
+        return loadedProgramPoints != null ? loadedProgramPoints : new TreeMap<>();
     }
 
     private FunctionInitializer compileTypeSpecialization(final MethodType actualCallSiteType, final ScriptObject runtimeScope, final boolean persist) {
@@ -762,7 +762,7 @@ public final class RecompilableScriptFunctionData extends ScriptFunctionData imp
         final MethodType generalized = changed ? MethodType.methodType(noCalleeThisType.returnType(), paramTypes) : noCalleeThisType;
 
         if (callSiteParamCount < getArity()) {
-            return generalized.appendParameterTypes(Collections.<Class<?>>nCopies(getArity() - callSiteParamCount, Object.class));
+            return generalized.appendParameterTypes(Collections.nCopies(getArity() - callSiteParamCount, Object.class));
         }
         return generalized;
     }

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/RecompilableScriptFunctionData.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/RecompilableScriptFunctionData.java
@@ -466,9 +466,8 @@ public final class RecompilableScriptFunctionData extends ScriptFunctionData imp
 
         // Asynchronously serialize split functions.
         if (isSplit) {
-            astSerializerExecutorService.execute(() -> {
-                cachedAst = new SerializedAst(symbolClonedAst, ref);
-            });
+            astSerializerExecutorService.execute(() ->
+                cachedAst = new SerializedAst(symbolClonedAst, ref));
         }
     }
 
@@ -595,7 +594,7 @@ public final class RecompilableScriptFunctionData extends ScriptFunctionData imp
             @Override
             protected Node leaveDefault(final Node node) {
                 return ensureUniqueLabels(node);
-            };
+            }
 
             private Node ensureUniqueLabels(final Node node) {
                 // If we're returning a cached AST, we must also ensure unique labels

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptEnvironment.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptEnvironment.java
@@ -404,7 +404,7 @@ public final class ScriptEnvironment {
         }
 
         final LoggingOption loggingOption = (LoggingOption)options.get("log");
-        this._loggers = loggingOption == null ? new HashMap<String, LoggerInfo>() : loggingOption.getLoggers();
+        this._loggers = loggingOption == null ? new HashMap<>() : loggingOption.getLoggers();
 
         final LoggerInfo timeLoggerInfo = _loggers.get(Timing.getLoggerName());
         this._timing = new Timing(timeLoggerInfo != null && timeLoggerInfo.getLevel() != Level.OFF);

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptEnvironment.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptEnvironment.java
@@ -469,7 +469,7 @@ public final class ScriptEnvironment {
      * @return true if enabled
      */
     public boolean isTimingEnabled() {
-        return _timing != null ? _timing.isEnabled() : false;
+        return _timing != null && _timing.isEnabled();
     }
 
     /**

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptFunction.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptFunction.java
@@ -804,7 +804,7 @@ public class ScriptFunction extends ScriptObject {
         final CompiledFunction cf = data.getBestConstructor(type, scope, CompiledFunction.NO_FUNCTIONS);
         final GuardedInvocation bestCtorInv = cf.createConstructorInvocation();
         //TODO - ClassCastException
-        return new GuardedInvocation(pairArguments(bestCtorInv.getInvocation(), type), getFunctionGuard(this, cf.getFlags()), bestCtorInv.getSwitchPoints(), null);
+        return new GuardedInvocation(pairArguments(bestCtorInv.getInvocation(), type), getFunctionGuard(this), bestCtorInv.getSwitchPoints(), null);
     }
 
     private static Object wrapFilter(final Object obj) {
@@ -1005,8 +1005,7 @@ public class ScriptFunction extends ScriptObject {
                 boundHandle,
                 guard == null ?
                         getFunctionGuard(
-                                this,
-                                cf.getFlags()) :
+                                this) :
                         guard,
                 spsArray,
                 exceptionGuard);
@@ -1305,7 +1304,7 @@ public class ScriptFunction extends ScriptObject {
      *
      * @return method handle for guard
      */
-    private static MethodHandle getFunctionGuard(final ScriptFunction function, final int flags) {
+    private static MethodHandle getFunctionGuard(final ScriptFunction function) {
         assert function.data != null;
         // Built-in functions have a 1-1 correspondence to their ScriptFunctionData, so we can use a cheaper identity
         // comparison for them.

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptFunction.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptFunction.java
@@ -1014,7 +1014,7 @@ public class ScriptFunction extends ScriptObject {
 
     private static Lookup getLookupPrivileged(final CallSiteDescriptor desc) {
         // NOTE: we'd rather not make NashornCallSiteDescriptor.getLookupPrivileged public.
-        return AccessController.doPrivileged((PrivilegedAction<Lookup>)()->desc.getLookup(),
+        return AccessController.doPrivileged((PrivilegedAction<Lookup>) desc::getLookup,
                 GET_LOOKUP_PERMISSION_CONTEXT);
     }
 

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptFunction.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptFunction.java
@@ -1217,7 +1217,7 @@ public class ScriptFunction extends ScriptObject {
         // Spread call site descriptor for the delegate createApplyOrCallCall invocation. We drop vararg array and
         // replace it with a list of Object.class.
         final MethodType spreadType = descType.dropParameterTypes(paramCount - 1, paramCount).appendParameterTypes(
-                Collections.<Class<?>>nCopies(varArgCount, Object.class));
+                Collections.nCopies(varArgCount, Object.class));
         final CallSiteDescriptor spreadDesc = desc.changeMethodType(spreadType);
 
         // Delegate back to createApplyOrCallCall with the spread (that is, reverted to non-vararg) request/

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptFunction.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptFunction.java
@@ -494,7 +494,7 @@ public class ScriptFunction extends ScriptObject {
     }
 
     private static boolean needsWrappedThis(final Object fn) {
-        return fn instanceof ScriptFunction ? ((ScriptFunction) fn).needsWrappedThis() : false;
+        return fn instanceof ScriptFunction && ((ScriptFunction) fn).needsWrappedThis();
     }
 
     /**

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptFunctionData.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptFunctionData.java
@@ -251,8 +251,7 @@ public abstract class ScriptFunctionData implements Serializable {
             throw typeError("not.a.constructor", toSource());
         }
         // Constructor call sites don't have a "this", but getBest is meant to operate on "callee, this, ..." style
-        final CompiledFunction cf = getBest(callSiteType.insertParameterTypes(1, Object.class), runtimeScope, forbidden);
-        return cf;
+        return getBest(callSiteType.insertParameterTypes(1, Object.class), runtimeScope, forbidden);
     }
 
     /**

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptFunctionData.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptFunctionData.java
@@ -222,16 +222,8 @@ public abstract class ScriptFunctionData implements Serializable {
      * @return verbose description
      */
     public String toStringVerbose() {
-        final StringBuilder sb = new StringBuilder();
-
-        sb.append("name='").
-                append(name.isEmpty() ? "<anonymous>" : name).
-                append("' ").
-                append(code.size()).
-                append(" invokers=").
-                append(code);
-
-        return sb.toString();
+        return "name='" + (name.isEmpty() ? "<anonymous>" : name) + "' " + code.size() + " invokers="
+           + code;
     }
 
     /**

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptObject.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptObject.java
@@ -2491,7 +2491,7 @@ public abstract class ScriptObject implements PropertyAccess, Cloneable {
                 explicitInstanceOfCheck ? null : ClassCastException.class);
     }
 
-    private abstract static class ScriptObjectIterator <T extends Object> implements Iterator<T> {
+    private abstract static class ScriptObjectIterator <T> implements Iterator<T> {
         protected T[] values;
         protected final ScriptObject object;
         private int index;

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptObject.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptObject.java
@@ -2653,10 +2653,6 @@ public abstract class ScriptObject implements PropertyAccess, Cloneable {
 
             Arrays.fill(fillers, UNDEFINED);
 
-            if (isCalleeVarArg) {
-                fillers[missingArgs - 1] = ScriptRuntime.EMPTY_ARRAY;
-            }
-
             return MH.insertArguments(
                 methodHandle,
                 parameterCount - missingArgs,

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptObject.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptObject.java
@@ -2081,7 +2081,7 @@ public abstract class ScriptObject implements PropertyAccess, Cloneable {
         if (returnClass.isPrimitive()) {
             //turn e.g. get with a double into getDouble
             final String returnTypeName = returnClass.getName();
-            name = "get" + Character.toUpperCase(returnTypeName.charAt(0)) + returnTypeName.substring(1, returnTypeName.length());
+            name = "get" + Character.toUpperCase(returnTypeName.charAt(0)) + returnTypeName.substring(1);
         } else {
             name = "get";
         }

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptObject.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptObject.java
@@ -2724,31 +2724,31 @@ public abstract class ScriptObject implements PropertyAccess, Cloneable {
             return;
         }
 
-        if (newLength < arrayLength) {
-           long actualLength = newLength;
+        // newLength < arrayLength
 
-           // Check for numeric keys in property map and delete them or adjust length, depending on whether
-           // they're defined as configurable. See ES5 #15.4.5.2
-           if (getMap().containsArrayKeys()) {
+       long actualLength = newLength;
 
-               for (long l = arrayLength - 1; l >= newLength; l--) {
-                   final FindProperty find = findProperty(JSType.toString(l), false);
+       // Check for numeric keys in property map and delete them or adjust length, depending on whether
+       // they're defined as configurable. See ES5 #15.4.5.2
+       if (getMap().containsArrayKeys()) {
 
-                   if (find != null) {
+           for (long l = arrayLength - 1; l >= newLength; l--) {
+               final FindProperty find = findProperty(JSType.toString(l), false);
 
-                       if (find.getProperty().isConfigurable()) {
-                           deleteOwnProperty(find.getProperty());
-                       } else {
-                           actualLength = l + 1;
-                           break;
-                       }
+               if (find != null) {
+
+                   if (find.getProperty().isConfigurable()) {
+                       deleteOwnProperty(find.getProperty());
+                   } else {
+                       actualLength = l + 1;
+                       break;
                    }
                }
            }
-
-           setArray(data.shrink(actualLength));
-           data.setLength(actualLength);
        }
+
+       setArray(data.shrink(actualLength));
+       data.setLength(actualLength);
     }
 
     private int getInt(final int index, final Object key, final int programPoint) {

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptObject.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptObject.java
@@ -265,7 +265,7 @@ public abstract class ScriptObject implements PropertyAccess, Cloneable {
     }
 
     private static int alignUp(final int size, final int alignment) {
-        return size + alignment - 1 & ~(alignment - 1);
+        return size + alignment - 1 & -alignment;
     }
 
     /**

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptObject.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptObject.java
@@ -2704,11 +2704,7 @@ public abstract class ScriptObject implements PropertyAccess, Cloneable {
         }
 
         if (length < n) {
-            final Object fill = UNDEFINED;
-
-            for (int i = length; i < n; i++) {
-                newArray[i] = fill;
-            }
+            Arrays.fill(newArray, length, n, UNDEFINED);
         }
 
         return newArray;

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptRuntime.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptRuntime.java
@@ -240,12 +240,7 @@ public final class ScriptRuntime {
             break;
         }
 
-        final StringBuilder sb = new StringBuilder();
-        sb.append("[object ");
-        sb.append(className);
-        sb.append(']');
-
-        return sb.toString();
+        return "[object " + className + ']';
     }
 
     /**

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptRuntime.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptRuntime.java
@@ -325,7 +325,6 @@ public final class ScriptRuntime {
     // value Iterator for important Java objects - arrays, maps, iterables.
     private static Iterator<?> iteratorForJavaArrayOrList(final Object obj) {
         if (obj != null && obj.getClass().isArray()) {
-            final Object array  = obj;
             final int    length = Array.getLength(obj);
 
             return new Iterator<>() {
@@ -341,7 +340,7 @@ public final class ScriptRuntime {
                     if (index >= length) {
                         throw new NoSuchElementException();
                     }
-                    return Array.get(array, index++);
+                    return Array.get(obj, index++);
                 }
 
                 @Override
@@ -419,8 +418,7 @@ public final class ScriptRuntime {
                 public Object next() {
                     Map.Entry<?,?> next = (Map.Entry)iter.next();
                     Object[] keyvalue = new Object[]{next.getKey(), next.getValue()};
-                    NativeArray array = NativeJava.from(null, keyvalue);
-                    return array;
+                    return NativeJava.from(null, keyvalue);
                 }
 
                 @Override

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptRuntime.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptRuntime.java
@@ -333,7 +333,7 @@ public final class ScriptRuntime {
             final Object array  = obj;
             final int    length = Array.getLength(obj);
 
-            return new Iterator<Object>() {
+            return new Iterator<>() {
                 private int index = 0;
 
                 @Override
@@ -412,8 +412,8 @@ public final class ScriptRuntime {
             }
 
         if (obj instanceof Map) {
-            return new Iterator<Object>() {
-                private Iterator<?> iter = ((Map<?,?>)obj).entrySet().iterator();
+            return new Iterator<>() {
+                private final Iterator<?> iter = ((Map<?,?>)obj).entrySet().iterator();
 
                 @Override
                 public boolean hasNext() {
@@ -443,7 +443,7 @@ public final class ScriptRuntime {
         final MethodHandle doneInvoker = AbstractIterator.getDoneInvoker(global);
         final MethodHandle valueInvoker = AbstractIterator.getValueInvoker(global);
 
-        return new Iterator<Object>() {
+        return new Iterator<>() {
 
             private Object nextResult = nextResult();
 

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptingFunctions.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptingFunctions.java
@@ -45,7 +45,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import org.openjdk.nashorn.internal.objects.NativeArray;
-import static org.openjdk.nashorn.internal.runtime.ECMAErrors.rangeError;
 
 /**
  * Global functions supported only in scripting mode.

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptingFunctions.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptingFunctions.java
@@ -181,9 +181,9 @@ public final class ScriptingFunctions {
             final ScriptObject envProperties = (ScriptObject)env;
 
             // Copy ENV variables.
-            envProperties.entrySet().stream().forEach((entry) -> {
-                environment.put(JSType.toString(entry.getKey()), JSType.toString(entry.getValue()));
-            });
+            envProperties.entrySet().forEach((entry) ->
+                environment.put(JSType.toString(entry.getKey()), JSType.toString(entry.getValue()))
+            );
         }
 
         // get the $EXEC function object from the global object

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptingFunctions.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptingFunctions.java
@@ -150,8 +150,7 @@ public final class ScriptingFunctions {
 
         if (arg0 instanceof NativeArray) {
             final String[] array = (String[])JSType.toJavaArray(arg0, String.class);
-            tokens = new ArrayList<>();
-            tokens.addAll(Arrays.asList(array));
+            tokens = new ArrayList<>(Arrays.asList(array));
         } else {
             script = JSType.toString(arg0);
         }

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/Source.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/Source.java
@@ -773,13 +773,11 @@ public final class Source implements Loggable {
         final char[]        arr = new char[BUF_SIZE];
         final StringBuilder sb  = new StringBuilder();
 
-        try {
+        try (reader) {
             int numChars;
             while ((numChars = reader.read(arr, 0, arr.length)) > 0) {
                 sb.append(arr, 0, numChars);
             }
-        } finally {
-            reader.close();
         }
 
         return sb.toString().toCharArray();
@@ -952,7 +950,7 @@ public final class Source implements Loggable {
 
     static byte[] readBytes(final InputStream is) throws IOException {
         final byte[] arr = new byte[BUF_SIZE];
-        try {
+        try (is) {
             try (ByteArrayOutputStream buf = new ByteArrayOutputStream()) {
                 int numBytes;
                 while ((numBytes = is.read(arr, 0, arr.length)) > 0) {
@@ -960,8 +958,6 @@ public final class Source implements Loggable {
                 }
                 return buf.toByteArray();
             }
-        } finally {
-            is.close();
         }
     }
 

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/SpillProperty.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/SpillProperty.java
@@ -55,7 +55,7 @@ public class SpillProperty extends AccessorProperty {
         private final int slot;
         private final MethodHandle ensureSpillSize;
 
-        private static Accessors ACCESSOR_CACHE[] = new Accessors[512];
+        private static Accessors[] ACCESSOR_CACHE = new Accessors[512];
 
         //private static final Map<Integer, Reference<Accessors>> ACCESSOR_CACHE = Collections.synchronizedMap(new WeakHashMap<Integer, Reference<Accessors>>());
 
@@ -71,7 +71,7 @@ public class SpillProperty extends AccessorProperty {
                 do {
                     len *= 2;
                 } while (slot >= len);
-                final Accessors newCache[] = new Accessors[len];
+                final Accessors[] newCache = new Accessors[len];
                 System.arraycopy(ACCESSOR_CACHE, 0, newCache, 0, ACCESSOR_CACHE.length);
                 ACCESSOR_CACHE = newCache;
             }

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/arrays/ArrayData.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/arrays/ArrayData.java
@@ -262,7 +262,7 @@ public abstract class ArrayData {
      * @return size given, always &gt;= size
      */
     protected static int alignUp(final int size) {
-        return size + CHUNK_SIZE - 1 & ~(CHUNK_SIZE - 1);
+        return size + CHUNK_SIZE - 1 & -CHUNK_SIZE;
     }
 
     /**

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/arrays/ContinuousArrayData.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/arrays/ContinuousArrayData.java
@@ -348,6 +348,6 @@ public abstract class ContinuousArrayData extends ArrayData {
      * @return new arraydata
      */
     public ContinuousArrayData fastConcat(final ContinuousArrayData otherData) {
-        throw new ClassCastException(String.valueOf(getClass()) + " != " + String.valueOf(otherData.getClass()));
+        throw new ClassCastException(getClass() + " != " + otherData.getClass());
     }
 }

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/arrays/LengthNotWritableFilter.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/arrays/LengthNotWritableFilter.java
@@ -44,7 +44,7 @@ final class LengthNotWritableFilter extends ArrayFilter {
      * @param underlying array
      */
     LengthNotWritableFilter(final ArrayData underlying) {
-        this(underlying, new TreeMap<Long, Object>());
+        this(underlying, new TreeMap<>());
     }
 
     private LengthNotWritableFilter(final ArrayData underlying, final SortedMap<Long, Object> extraElements) {

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/arrays/TypedArrayData.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/arrays/TypedArrayData.java
@@ -28,9 +28,6 @@ package org.openjdk.nashorn.internal.runtime.arrays;
 import static org.openjdk.nashorn.internal.lookup.Lookup.MH;
 import java.lang.invoke.MethodHandle;
 import java.nio.Buffer;
-import jdk.dynalink.CallSiteDescriptor;
-import jdk.dynalink.linker.GuardedInvocation;
-import jdk.dynalink.linker.LinkRequest;
 import org.openjdk.nashorn.internal.lookup.Lookup;
 
 /**
@@ -165,7 +162,7 @@ public abstract class TypedArrayData<T extends Buffer> extends ContinuousArrayDa
         if (getter != null) {
             return Lookup.filterReturnType(getter, returnType);
         }
-        return getter;
+        return null;
     }
 
     @Override
@@ -178,27 +175,4 @@ public abstract class TypedArrayData<T extends Buffer> extends ContinuousArrayDa
         final MethodHandle mh = Lookup.filterArgumentType(setHas, 2, elementType);
         return MH.asType(mh, mh.type().changeParameterType(0, clazz));
     }
-
-    @Override
-    public GuardedInvocation findFastGetIndexMethod(final Class<? extends ArrayData> clazz, final CallSiteDescriptor desc, final LinkRequest request) {
-        final GuardedInvocation inv = super.findFastGetIndexMethod(clazz, desc, request);
-
-        if (inv != null) {
-            return inv;
-        }
-
-        return null;
-    }
-
-    @Override
-    public GuardedInvocation findFastSetIndexMethod(final Class<? extends ArrayData> clazz, final CallSiteDescriptor desc, final LinkRequest request) { // array, index, value
-        final GuardedInvocation inv = super.findFastSetIndexMethod(clazz, desc, request);
-
-        if (inv != null) {
-            return inv;
-        }
-
-        return null;
-    }
-
 }

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/events/RuntimeEvent.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/events/RuntimeEvent.java
@@ -64,16 +64,8 @@ public class RuntimeEvent<T> {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-
-        sb.append('[').
-            append(level).
-            append("] ").
-            append(value == null ? "null" : getValueClass().getSimpleName()).
-            append(" value=").
-            append(value);
-
-        return sb.toString();
+        return "[" + level + "] " + (value == null ? "null" : getValueClass().getSimpleName())
+                    + " value=" + value;
     }
 
     /**

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/BrowserJSObjectLinker.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/BrowserJSObjectLinker.java
@@ -82,7 +82,7 @@ final class BrowserJSObjectLinker implements TypeBasedGuardingDynamicLinker {
         return Bootstrap.asTypeSafeReturn(inv, linkerServices, desc);
     }
 
-    private GuardedInvocation lookup(final CallSiteDescriptor desc, final LinkRequest request, final LinkerServices linkerServices) throws Exception {
+    private GuardedInvocation lookup(final CallSiteDescriptor desc, final LinkRequest request, final LinkerServices linkerServices) {
         GuardedInvocation inv;
         try {
             inv = nashornBeansLinker.getGuardedInvocation(request, linkerServices);

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/ClassAndLoader.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/ClassAndLoader.java
@@ -124,12 +124,9 @@ final class ClassAndLoader {
             return new ClassAndLoader(types[0], false);
         }
 
-        return AccessController.doPrivileged(new PrivilegedAction<ClassAndLoader>() {
-            @Override
-            public ClassAndLoader run() {
-                return getDefiningClassAndLoaderPrivileged(types);
-            }
-        }, GET_LOADER_ACC_CTXT);
+        return AccessController.doPrivileged((PrivilegedAction<ClassAndLoader>) () ->
+            getDefiningClassAndLoaderPrivileged(types), GET_LOADER_ACC_CTXT
+        );
     }
 
     static ClassAndLoader getDefiningClassAndLoaderPrivileged(final Class<?>[] types) {

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/JavaAdapterBytecodeGenerator.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/JavaAdapterBytecodeGenerator.java
@@ -1191,16 +1191,13 @@ final class JavaAdapterBytecodeGenerator {
      * @return a collection of method infos representing those methods that we never override in adapter classes.
      */
     private static Collection<MethodInfo> getExcludedMethods() {
-        return AccessController.doPrivileged(new PrivilegedAction<Collection<MethodInfo>>() {
-            @Override
-            public Collection<MethodInfo> run() {
-                try {
-                    return Arrays.asList(
-                            new MethodInfo(Object.class, "finalize"),
-                            new MethodInfo(Object.class, "clone"));
-                } catch (final NoSuchMethodException e) {
-                    throw new AssertionError(e);
-                }
+        return AccessController.doPrivileged((PrivilegedAction<Collection<MethodInfo>>) () -> {
+            try {
+                return List.of(
+                        new MethodInfo(Object.class, "finalize"),
+                        new MethodInfo(Object.class, "clone"));
+            } catch (final NoSuchMethodException e) {
+                throw new AssertionError(e);
             }
         }, GET_DECLARED_MEMBERS_ACC_CTXT);
     }

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/JavaAdapterBytecodeGenerator.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/JavaAdapterBytecodeGenerator.java
@@ -313,7 +313,6 @@ final class JavaAdapterBytecodeGenerator {
         // The class we use to primarily name our adapter is either the superclass, or if it is Object (meaning we're
         // just implementing interfaces or extending Object), then the first implemented interface or Object.
         final Class<?> namingType = superType == Object.class ? (interfaces.isEmpty()? Object.class : interfaces.get(0)) : superType;
-        final Package pkg = namingType.getPackage();
         final String namingTypeName = Type.getInternalName(namingType);
         final StringBuilder buf = new StringBuilder();
         buf.append(ADAPTER_PACKAGE_INTERNAL).append(namingTypeName.replace('/', '_'));

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/JavaAdapterBytecodeGenerator.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/JavaAdapterBytecodeGenerator.java
@@ -1043,8 +1043,8 @@ final class JavaAdapterBytecodeGenerator {
         return emitSuperCall(mv, null, INIT, methodDesc, true);
     }
 
-    private int emitSuperCall(final InstructionAdapter mv, final Class<?> owner, final String name, final String methodDesc) {
-        return emitSuperCall(mv, owner, name, methodDesc, false);
+    private void emitSuperCall(final InstructionAdapter mv, final Class<?> owner, final String name, final String methodDesc) {
+        emitSuperCall(mv, owner, name, methodDesc, false);
     }
 
     private int emitSuperCall(final InstructionAdapter mv, final Class<?> owner, final String name, final String methodDesc, final boolean constructor) {

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/JavaAdapterBytecodeGenerator.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/JavaAdapterBytecodeGenerator.java
@@ -326,7 +326,7 @@ final class JavaAdapterBytecodeGenerator {
         while(it.hasNext()) {
             buf.append("$$").append(it.next().getSimpleName());
         }
-        return buf.toString().substring(0, Math.min(MAX_GENERATED_TYPE_NAME_LENGTH, buf.length()));
+        return buf.substring(0, Math.min(MAX_GENERATED_TYPE_NAME_LENGTH, buf.length()));
     }
 
     /**

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/JavaAdapterBytecodeGenerator.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/JavaAdapterBytecodeGenerator.java
@@ -57,7 +57,6 @@ import java.security.AccessControlContext;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.security.ProtectionDomain;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/JavaAdapterClassLoader.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/JavaAdapterClassLoader.java
@@ -25,8 +25,6 @@
 
 package org.openjdk.nashorn.internal.runtime.linker;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.security.AccessControlContext;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -36,7 +34,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Set;
 import jdk.dynalink.beans.StaticClass;
 import org.openjdk.nashorn.internal.codegen.DumpBytecode;
 import org.openjdk.nashorn.internal.runtime.Context;

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/JavaAdapterClassLoader.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/JavaAdapterClassLoader.java
@@ -76,14 +76,11 @@ final class JavaAdapterClassLoader {
      */
     StaticClass generateClass(final ClassLoader parentLoader, final ProtectionDomain protectionDomain) {
         assert protectionDomain != null;
-        return AccessController.doPrivileged(new PrivilegedAction<StaticClass>() {
-            @Override
-            public StaticClass run() {
-                try {
-                    return StaticClass.forClass(Class.forName(className, true, createClassLoader(parentLoader, protectionDomain)));
-                } catch (final ClassNotFoundException e) {
-                    throw new AssertionError(e); // cannot happen
-                }
+        return AccessController.doPrivileged((PrivilegedAction<StaticClass>) () -> {
+            try {
+                return StaticClass.forClass(Class.forName(className, true, createClassLoader(parentLoader, protectionDomain)));
+            } catch (final ClassNotFoundException e) {
+                throw new AssertionError(e); // cannot happen
             }
         }, CREATE_LOADER_ACC_CTXT);
     }
@@ -137,12 +134,7 @@ final class JavaAdapterClassLoader {
                 if(name.equals(className)) {
                     assert classBytes != null : "what? already cleared .class bytes!!";
 
-                    final Context ctx = AccessController.doPrivileged(new PrivilegedAction<Context>() {
-                        @Override
-                        public Context run() {
-                            return Context.getContext();
-                        }
-                    }, GET_CONTEXT_ACC_CTXT);
+                    final Context ctx = AccessController.doPrivileged((PrivilegedAction<Context>) Context::getContext, GET_CONTEXT_ACC_CTXT);
                     DumpBytecode.dumpBytecode(ctx.getEnv(), ctx.getLogger(org.openjdk.nashorn.internal.codegen.Compiler.class), classBytes, name);
                     return defineClass(name, classBytes, 0, classBytes.length, protectionDomain);
                 }

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/JavaAdapterClassLoader.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/JavaAdapterClassLoader.java
@@ -120,7 +120,7 @@ final class JavaAdapterClassLoader {
                     // SecurityException for nashorn's classes!. For adapter's to work, we
                     // should be able to refer to the few classes it needs in its implementation.
                     if(VISIBLE_INTERNAL_CLASS_NAMES.contains(name)) {
-                        return myLoader != null? myLoader.loadClass(name) : Class.forName(name, false, myLoader);
+                        return myLoader != null? myLoader.loadClass(name) : Class.forName(name, false, null);
                     }
                     throw se;
                 }

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/JavaAdapterFactory.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/JavaAdapterFactory.java
@@ -161,12 +161,7 @@ public final class JavaAdapterFactory {
     }
 
     private static ProtectionDomain getProtectionDomain(final Class<?> clazz) {
-        return AccessController.doPrivileged(new PrivilegedAction<ProtectionDomain>() {
-            @Override
-            public ProtectionDomain run() {
-                return clazz.getProtectionDomain();
-            }
-        });
+        return AccessController.doPrivileged((PrivilegedAction<ProtectionDomain>) clazz::getProtectionDomain);
     }
 
     /**
@@ -266,16 +261,13 @@ public final class JavaAdapterFactory {
 
 
         final Class<?> effectiveSuperClass = superClass == null ? Object.class : superClass;
-        return AccessController.doPrivileged(new PrivilegedAction<AdapterInfo>() {
-            @Override
-            public AdapterInfo run() {
-                try {
-                    return new AdapterInfo(effectiveSuperClass, interfaces, definingClassAndLoader);
-                } catch (final AdaptationException e) {
-                    return new AdapterInfo(e.getAdaptationResult());
-                } catch (final RuntimeException e) {
-                    return new AdapterInfo(new AdaptationResult(Outcome.ERROR_OTHER, e, Arrays.toString(types), e.toString()));
-                }
+        return AccessController.doPrivileged((PrivilegedAction<AdapterInfo>) () -> {
+            try {
+                return new AdapterInfo(effectiveSuperClass, interfaces, definingClassAndLoader);
+            } catch (final AdaptationException e) {
+                return new AdapterInfo(e.getAdaptationResult());
+            } catch (final RuntimeException e) {
+                return new AdapterInfo(new AdaptationResult(Outcome.ERROR_OTHER, e, types.toString(), e.toString()));
             }
         }, CREATE_ADAPTER_INFO_ACC_CTXT);
     }

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/JavaAdapterFactory.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/JavaAdapterFactory.java
@@ -93,7 +93,7 @@ public final class JavaAdapterFactory {
     /**
      * A mapping from an original Class object to AdapterInfo representing the adapter for the class it represents.
      */
-    private static final ClassValue<Map<List<Class<?>>, AdapterInfo>> ADAPTER_INFO_MAPS = new ClassValue<Map<List<Class<?>>, AdapterInfo>>() {
+    private static final ClassValue<Map<List<Class<?>>, AdapterInfo>> ADAPTER_INFO_MAPS = new ClassValue<>() {
         @Override
         protected Map<List<Class<?>>, AdapterInfo> computeValue(final Class<?> type) {
             return new HashMap<>();

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/JavaAdapterServices.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/JavaAdapterServices.java
@@ -230,19 +230,14 @@ public final class JavaAdapterServices {
         cw.visitEnd();
         final byte[] bytes = cw.toByteArray();
 
-        final ClassLoader loader = AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
+        final ClassLoader loader = AccessController.doPrivileged((PrivilegedAction<ClassLoader>) () -> new SecureClassLoader(null) {
             @Override
-            public ClassLoader run() {
-                return new SecureClassLoader(null) {
-                    @Override
-                    protected Class<?> findClass(final String name) throws ClassNotFoundException {
-                        if(name.equals(className)) {
-                            return defineClass(name, bytes, 0, bytes.length, new ProtectionDomain(
-                                    new CodeSource(null, (CodeSigner[])null), new Permissions()));
-                        }
-                        throw new ClassNotFoundException(name);
-                    }
-                };
+            protected Class<?> findClass(final String name) throws ClassNotFoundException {
+                if(name.equals(className)) {
+                    return defineClass(name, bytes, 0, bytes.length, new ProtectionDomain(
+                            new CodeSource(null, (CodeSigner[])null), new Permissions()));
+                }
+                throw new ClassNotFoundException(name);
             }
         });
 

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/NashornBeansLinker.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/NashornBeansLinker.java
@@ -86,7 +86,7 @@ public class NashornBeansLinker implements GuardingDynamicLinker {
     }
 
     // cache of @FunctionalInterface method of implementor classes
-    private static final ClassValue<String> FUNCTIONAL_IFACE_METHOD_NAME = new ClassValue<String>() {
+    private static final ClassValue<String> FUNCTIONAL_IFACE_METHOD_NAME = new ClassValue<>() {
         @Override
         protected String computeValue(final Class<?> type) {
             return findFunctionalInterfaceMethodName(type);

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/NashornBottomLinker.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/NashornBottomLinker.java
@@ -45,7 +45,6 @@ import jdk.dynalink.linker.GuardingDynamicLinker;
 import jdk.dynalink.linker.GuardingTypeConverterFactory;
 import jdk.dynalink.linker.LinkRequest;
 import jdk.dynalink.linker.LinkerServices;
-import jdk.dynalink.linker.support.Guards;
 import jdk.dynalink.linker.support.Lookup;
 import org.openjdk.nashorn.internal.codegen.types.Type;
 import org.openjdk.nashorn.internal.runtime.ECMAException;

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/NashornBottomLinker.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/NashornBottomLinker.java
@@ -62,8 +62,7 @@ import org.openjdk.nashorn.internal.runtime.UnwarrantedOptimismException;
 final class NashornBottomLinker implements GuardingDynamicLinker, GuardingTypeConverterFactory {
 
     @Override
-    public GuardedInvocation getGuardedInvocation(final LinkRequest linkRequest, final LinkerServices linkerServices)
-            throws Exception {
+    public GuardedInvocation getGuardedInvocation(final LinkRequest linkRequest, final LinkerServices linkerServices) {
         final Object self = linkRequest.getReceiver();
 
         if (self == null) {
@@ -99,7 +98,7 @@ final class NashornBottomLinker implements GuardingDynamicLinker, GuardingTypeCo
         MISSING_PROPERTY_REMOVER = lookup.findOwnStatic("missingPropertyRemover", boolean.class, Object.class, Object.class);
     }
 
-    private static GuardedInvocation linkBean(final LinkRequest linkRequest) throws Exception {
+    private static GuardedInvocation linkBean(final LinkRequest linkRequest) {
         final CallSiteDescriptor desc = linkRequest.getCallSiteDescriptor();
         final Object self = linkRequest.getReceiver();
         switch (NashornCallSiteDescriptor.getStandardOperation(desc)) {
@@ -126,7 +125,7 @@ final class NashornBottomLinker implements GuardingDynamicLinker, GuardingTypeCo
         }
     }
 
-    static MethodHandle linkMissingBeanMember(final LinkRequest linkRequest, final LinkerServices linkerServices) throws Exception {
+    static MethodHandle linkMissingBeanMember(final LinkRequest linkRequest, final LinkerServices linkerServices) {
         final CallSiteDescriptor desc = linkRequest.getCallSiteDescriptor();
         final String operand = NashornCallSiteDescriptor.getOperand(desc);
         final boolean strict = NashornCallSiteDescriptor.isStrict(desc);
@@ -209,8 +208,8 @@ final class NashornBottomLinker implements GuardingDynamicLinker, GuardingTypeCo
     }
 
     @Override
-    public GuardedInvocation convertToType(final Class<?> sourceType, final Class<?> targetType, final Supplier<MethodHandles.Lookup> lookupSupplier) throws Exception {
-        final GuardedInvocation gi = convertToTypeNoCast(sourceType, targetType);
+    public GuardedInvocation convertToType(final Class<?> sourceType, final Class<?> targetType, final Supplier<MethodHandles.Lookup> lookupSupplier) {
+        final GuardedInvocation gi = convertToTypeNoCast(targetType);
         return gi == null ? null : gi.asType(MH.type(targetType, sourceType));
     }
 
@@ -218,12 +217,10 @@ final class NashornBottomLinker implements GuardingDynamicLinker, GuardingTypeCo
      * Main part of the implementation of {@link GuardingTypeConverterFactory#convertToType} that doesn't
      * care about adapting the method signature; that's done by the invoking method. Returns conversion
      * from Object to String/number/boolean (JS primitive types).
-     * @param sourceType the source type
      * @param targetType the target type
      * @return a guarded invocation that converts from the source type to the target type.
-     * @throws Exception if something goes wrong
      */
-    private static GuardedInvocation convertToTypeNoCast(final Class<?> sourceType, final Class<?> targetType) throws Exception {
+    private static GuardedInvocation convertToTypeNoCast(final Class<?> targetType) {
         final MethodHandle mh = CONVERTERS.get(targetType);
         if (mh != null) {
             return new GuardedInvocation(mh);

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/NashornCallSiteDescriptor.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/NashornCallSiteDescriptor.java
@@ -44,7 +44,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Stream;
 import jdk.dynalink.CallSiteDescriptor;
 import jdk.dynalink.NamedOperation;
@@ -167,10 +166,10 @@ public final class NashornCallSiteDescriptor extends CallSiteDescriptor {
      */
     public static final int FLAGS_MASK = (1 << CALLSITE_PROGRAM_POINT_SHIFT) - 1;
 
-    private static final ClassValue<ConcurrentMap<NashornCallSiteDescriptor, NashornCallSiteDescriptor>> canonicals =
-            new ClassValue<ConcurrentMap<NashornCallSiteDescriptor,NashornCallSiteDescriptor>>() {
+    private static final ClassValue<Map<NashornCallSiteDescriptor, NashornCallSiteDescriptor>> canonicals =
+            new ClassValue<>() {
         @Override
-        protected ConcurrentMap<NashornCallSiteDescriptor, NashornCallSiteDescriptor> computeValue(final Class<?> type) {
+        protected Map<NashornCallSiteDescriptor, NashornCallSiteDescriptor> computeValue(final Class<?> type) {
             return new ConcurrentHashMap<>();
         }
     };

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/NashornCallSiteDescriptor.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/NashornCallSiteDescriptor.java
@@ -290,7 +290,7 @@ public final class NashornCallSiteDescriptor extends CallSiteDescriptor {
         if (csd instanceof NashornCallSiteDescriptor) {
             return ((NashornCallSiteDescriptor)csd).getLookupPrivileged();
         }
-        return AccessController.doPrivileged((PrivilegedAction<Lookup>)()->csd.getLookup(), GET_LOOKUP_PERMISSION_CONTEXT);
+        return AccessController.doPrivileged((PrivilegedAction<Lookup>) csd::getLookup, GET_LOOKUP_PERMISSION_CONTEXT);
     }
 
     @Override

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/NashornLinker.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/NashornLinker.java
@@ -173,12 +173,7 @@ final class NashornLinker implements TypeBasedGuardingDynamicLinker, GuardingTyp
     }
 
     private static MethodHandles.Lookup getCurrentLookup(final Supplier<MethodHandles.Lookup> lookupSupplier) {
-        return AccessController.doPrivileged(new PrivilegedAction<MethodHandles.Lookup>() {
-            @Override
-            public MethodHandles.Lookup run() {
-                return lookupSupplier.get();
-            }
-        }, GET_LOOKUP_PERMISSION_CONTEXT);
+        return AccessController.doPrivileged((PrivilegedAction<MethodHandles.Lookup>) lookupSupplier::get, GET_LOOKUP_PERMISSION_CONTEXT);
     }
 
     /**

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/NashornLinker.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/NashornLinker.java
@@ -71,7 +71,7 @@ final class NashornLinker implements TypeBasedGuardingDynamicLinker, GuardingTyp
     private static final AccessControlContext GET_LOOKUP_PERMISSION_CONTEXT =
             AccessControlContextFactory.createAccessControlContext(SecureLookupSupplier.GET_LOOKUP_PERMISSION_NAME);
 
-    private static final ClassValue<MethodHandle> ARRAY_CONVERTERS = new ClassValue<MethodHandle>() {
+    private static final ClassValue<MethodHandle> ARRAY_CONVERTERS = new ClassValue<>() {
         @Override
         protected MethodHandle computeValue(final Class<?> type) {
             return createArrayConverter(type);
@@ -345,7 +345,7 @@ final class NashornLinker implements TypeBasedGuardingDynamicLinker, GuardingTyp
 
     @SuppressWarnings("unused")
     private static Object createMirror(final Object obj) {
-        return obj instanceof ScriptObject? ScriptUtils.wrap((ScriptObject)obj) : obj;
+        return obj instanceof ScriptObject? ScriptUtils.wrap(obj) : obj;
     }
 
     @SuppressWarnings("unused")

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/NashornLinker.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/NashornLinker.java
@@ -91,7 +91,7 @@ final class NashornLinker implements TypeBasedGuardingDynamicLinker, GuardingTyp
     }
 
     @Override
-    public GuardedInvocation getGuardedInvocation(final LinkRequest request, final LinkerServices linkerServices) throws Exception {
+    public GuardedInvocation getGuardedInvocation(final LinkRequest request, final LinkerServices linkerServices) {
         final CallSiteDescriptor desc = request.getCallSiteDescriptor();
         return Bootstrap.asTypeSafeReturn(getGuardedInvocation(request, desc), linkerServices, desc);
     }
@@ -121,16 +121,15 @@ final class NashornLinker implements TypeBasedGuardingDynamicLinker, GuardingTyp
     }
 
     /**
-     * Main part of the implementation of {@link GuardingTypeConverterFactory#convertToType(Class, Class)} that doesn't
+     * Main part of the implementation of {@link GuardingTypeConverterFactory#convertToType(Class, Class, Supplier)} that doesn't
      * care about adapting the method signature; that's done by the invoking method. Returns either a built-in
      * conversion to primitive (or primitive wrapper) Java types or to String, or a just-in-time generated converter to
      * a SAM type (if the target type is a SAM type).
      * @param sourceType the source type
      * @param targetType the target type
      * @return a guarded invocation that converts from the source type to the target type.
-     * @throws Exception if something goes wrong
      */
-    private static GuardedInvocation convertToTypeNoCast(final Class<?> sourceType, final Class<?> targetType, final Supplier<MethodHandles.Lookup> lookupSupplier) throws Exception {
+    private static GuardedInvocation convertToTypeNoCast(final Class<?> sourceType, final Class<?> targetType, final Supplier<MethodHandles.Lookup> lookupSupplier) {
         final MethodHandle mh = JavaArgumentConverters.getConverter(targetType);
         if (mh != null) {
             return new GuardedInvocation(mh, canLinkTypeStatic(sourceType) ? null : IS_NASHORN_OR_UNDEFINED_TYPE);

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/NashornPrimitiveLinker.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/NashornPrimitiveLinker.java
@@ -64,8 +64,7 @@ final class NashornPrimitiveLinker implements TypeBasedGuardingDynamicLinker, Gu
     }
 
     @Override
-    public GuardedInvocation getGuardedInvocation(final LinkRequest request, final LinkerServices linkerServices)
-            throws Exception {
+    public GuardedInvocation getGuardedInvocation(final LinkRequest request, final LinkerServices linkerServices) {
         final Object self = request.getReceiver();
         return Bootstrap.asTypeSafeReturn(Global.primitiveLookup(request, self), linkerServices, request.getCallSiteDescriptor());
     }

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/ReflectionCheckLinker.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/ReflectionCheckLinker.java
@@ -81,8 +81,7 @@ final class ReflectionCheckLinker implements TypeBasedGuardingDynamicLinker{
     }
 
     @Override
-    public GuardedInvocation getGuardedInvocation(final LinkRequest origRequest, final LinkerServices linkerServices)
-            throws Exception {
+    public GuardedInvocation getGuardedInvocation(final LinkRequest origRequest, final LinkerServices linkerServices) {
         checkLinkRequest(origRequest);
         // let the next linker deal with actual linking
         return null;

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/logging/DebugLogger.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/logging/DebugLogger.java
@@ -82,35 +82,24 @@ public final class DebugLogger {
 
     private static Logger instantiateLogger(final String name, final Level level) {
         final Logger logger = java.util.logging.Logger.getLogger(name);
-        AccessController.doPrivileged(new PrivilegedAction<Void>() {
-            @Override
-            public Void run() {
-                for (final Handler h : logger.getHandlers()) {
-                    logger.removeHandler(h);
-                }
-
-                logger.setLevel(level);
-                logger.setUseParentHandlers(false);
-                final Handler c = new ConsoleHandler();
-
-                c.setFormatter(new Formatter() {
-                    @Override
-                    public String format(final LogRecord record) {
-                        final StringBuilder sb = new StringBuilder();
-
-                        sb.append('[')
-                        .append(record.getLoggerName())
-                        .append("] ")
-                        .append(record.getMessage())
-                        .append('\n');
-
-                        return sb.toString();
-                    }
-                });
-                logger.addHandler(c);
-                c.setLevel(level);
-                return null;
+        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+            for (final Handler h : logger.getHandlers()) {
+                logger.removeHandler(h);
             }
+
+            logger.setLevel(level);
+            logger.setUseParentHandlers(false);
+            final Handler c = new ConsoleHandler();
+
+            c.setFormatter(new Formatter() {
+                @Override
+                public String format(final LogRecord record) {
+                    return '[' + record.getLoggerName() + "] " + record.getMessage() + '\n';
+                }
+            });
+            logger.addHandler(c);
+            c.setLevel(level);
+            return null;
         }, createLoggerControlAccCtxt());
 
         return logger;

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/logging/DebugLogger.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/logging/DebugLogger.java
@@ -513,12 +513,7 @@ public final class DebugLogger {
      */
     public void log(final Level level, final String str) {
         if (isEnabled && !isQuiet && logger.isLoggable(level)) {
-            final StringBuilder sb = new StringBuilder();
-            for (int i = 0 ; i < indent ; i++) {
-                sb.append(' ');
-            }
-            sb.append(str);
-            logger.log(level, sb.toString());
+            logger.log(level, " ".repeat(Math.max(0, indent)) + str);
         }
     }
 

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/options/LoggingOption.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/options/LoggingOption.java
@@ -94,28 +94,24 @@ public class LoggingOption extends KeyValueOption {
      * @throws IllegalArgumentException if level or names cannot be parsed
      */
     private void initialize(final Map<String, String> logMap) throws IllegalArgumentException {
-        try {
-            for (final Entry<String, String> entry : logMap.entrySet()) {
-                Level level;
-                final String name        = lastPart(entry.getKey());
-                final String levelString = entry.getValue().toUpperCase(Locale.ENGLISH);
-                final boolean isQuiet;
+        for (final Entry<String, String> entry : logMap.entrySet()) {
+            Level level;
+            final String name        = lastPart(entry.getKey());
+            final String levelString = entry.getValue().toUpperCase(Locale.ENGLISH);
+            final boolean isQuiet;
 
-                if ("".equals(levelString)) {
-                    level = Level.INFO;
-                    isQuiet = false;
-                } else if ("QUIET".equals(levelString)) {
-                    level = Level.INFO;
-                    isQuiet = true;
-                } else {
-                    level = Level.parse(levelString);
-                    isQuiet = false;
-                }
-
-                loggers.put(name, new LoggerInfo(level, isQuiet));
+            if ("".equals(levelString)) {
+                level = Level.INFO;
+                isQuiet = false;
+            } else if ("QUIET".equals(levelString)) {
+                level = Level.INFO;
+                isQuiet = true;
+            } else {
+                level = Level.parse(levelString);
+                isQuiet = false;
             }
-        } catch (final IllegalArgumentException | SecurityException e) {
-            throw e;
+
+            loggers.put(name, new LoggerInfo(level, isQuiet));
         }
     }
 

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/options/Options.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/options/Options.java
@@ -473,12 +473,8 @@ public final class Options {
             if (parg.template.isHelp()) {
                 // check if someone wants help on an explicit arg
                 if (!argList.isEmpty()) {
-                    try {
-                        final OptionTemplate t = new ParsedArg(argList.get(0)).template;
-                        throw new IllegalOptionException(t);
-                    } catch (final IllegalArgumentException e) {
-                        throw e;
-                    }
+                    final OptionTemplate t = new ParsedArg(argList.get(0)).template;
+                    throw new IllegalOptionException(t);
                 }
                 throw new IllegalArgumentException(); // show help for
                 // everything

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/options/Options.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/options/Options.java
@@ -557,7 +557,7 @@ public final class Options {
         case "log":
             return new LoggingOption(value);
         case "boolean":
-            return new Option<>(value != null && Boolean.parseBoolean(value));
+            return new Option<>(Boolean.parseBoolean(value));
         case "integer":
             try {
                 return new Option<>(value == null ? 0 : Integer.parseInt(value));

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/options/Options.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/options/Options.java
@@ -151,22 +151,18 @@ public final class Options {
      */
     public static boolean getBooleanProperty(final String name, final Boolean defValue) {
         checkPropertyName(name);
-        return AccessController.doPrivileged(
-                new PrivilegedAction<Boolean>() {
-                    @Override
-                    public Boolean run() {
-                        try {
-                            final String property = System.getProperty(name);
-                            if (property == null && defValue != null) {
-                                return defValue;
-                            }
-                            return property != null && !"false".equalsIgnoreCase(property);
-                        } catch (final SecurityException e) {
-                            // if no permission to read, assume false
-                            return false;
-                        }
-                    }
-                }, READ_PROPERTY_ACC_CTXT);
+        return AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
+            try {
+                final String property = System.getProperty(name);
+                if (property == null && defValue != null) {
+                    return defValue;
+                }
+                return property != null && !"false".equalsIgnoreCase(property);
+            } catch (final SecurityException e) {
+                // if no permission to read, assume false
+                return false;
+            }
+        }, READ_PROPERTY_ACC_CTXT);
     }
 
     /**
@@ -188,18 +184,14 @@ public final class Options {
      */
     public static String getStringProperty(final String name, final String defValue) {
         checkPropertyName(name);
-        return AccessController.doPrivileged(
-                new PrivilegedAction<String>() {
-                    @Override
-                    public String run() {
-                        try {
-                            return System.getProperty(name, defValue);
-                        } catch (final SecurityException e) {
-                            // if no permission to read, assume the default value
-                            return defValue;
-                        }
-                    }
-                }, READ_PROPERTY_ACC_CTXT);
+        return AccessController.doPrivileged((PrivilegedAction<String>) () -> {
+            try {
+                return System.getProperty(name, defValue);
+            } catch (final SecurityException e) {
+                // if no permission to read, assume the default value
+                return defValue;
+            }
+        }, READ_PROPERTY_ACC_CTXT);
     }
 
     /**
@@ -211,18 +203,14 @@ public final class Options {
      */
     public static int getIntProperty(final String name, final int defValue) {
         checkPropertyName(name);
-        return AccessController.doPrivileged(
-                new PrivilegedAction<Integer>() {
-                    @Override
-                    public Integer run() {
-                        try {
-                            return Integer.getInteger(name, defValue);
-                        } catch (final SecurityException e) {
-                            // if no permission to read, assume the default value
-                            return defValue;
-                        }
-                    }
-                }, READ_PROPERTY_ACC_CTXT);
+        return AccessController.doPrivileged((PrivilegedAction<Integer>) () -> {
+            try {
+                return Integer.getInteger(name, defValue);
+            } catch (final SecurityException e) {
+                // if no permission to read, assume the default value
+                return defValue;
+            }
+        }, READ_PROPERTY_ACC_CTXT);
     }
 
     /**

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/options/Options.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/options/Options.java
@@ -331,7 +331,7 @@ public final class Options {
     private String key(final String shortKey) {
         String key = shortKey;
         while (key.startsWith("-")) {
-            key = key.substring(1, key.length());
+            key = key.substring(1);
         }
         key = key.replace("-", ".");
         final String keyPrefix = this.resource + ".option.";

--- a/test/nashorn/script/nosecurity/JDK-8044798.js
+++ b/test/nashorn/script/nosecurity/JDK-8044798.js
@@ -129,7 +129,7 @@ var stringCls = Java.type("java.lang.String").class;
 
 // private compile method of Context class
 var compileMethod = contextCls.getDeclaredMethod("compile",
-                sourceCls, errorMgrCls, booleanCls, booleanCls);
+                sourceCls, errorMgrCls, booleanCls);
 Reflector.setAccessible(compileMethod);
 
 var getContextMethod = contextCls.getMethod("getContext");
@@ -138,7 +138,7 @@ Reflector.setAccessible(getContextMethod);
 var sourceForMethod = sourceCls.getMethod("sourceFor", stringCls, stringCls);
 var scriptCls = compileMethod.invoke(getContextMethod.invoke(null),
     sourceForMethod.invoke(null, "test", "print('hello')"),
-    ThrowErrorManager.class.newInstance(), false, false);
+    ThrowErrorManager.class.newInstance(), false);
 
 var SCRIPT_CLASS_NAME_PREFIX = "org.openjdk.nashorn.internal.scripts.Script$";
 print("script class name pattern satisfied? " +


### PR DESCRIPTION
Most of Nashorn code was written to be compatible with Java 7 and never updated. It is high time to introduce diamonds, lambdas, modern collection operations (`List.of`, `Map.computeIfAbsent`, etc.), elimination of most StringBuffer use (since string concatenation has been indified) and bring it up to at least Java 11 standards.

In addition to these, I added more code tidying mostly governed by judicious evaluation of IntelliJ IDEA recommendations. Expressions have been simplified, statically known values have been respected, unused parameters and dead code removed. I did not blindly follow IDEA's recommendations; I refrained from eliminating asserts even when they're statically proven to always be true, as I like them as safeguards against future breakage. I also did not convert any switch statements into switch expressions; those have been introduced very recently in Java 14 and I'd rather give them more time. Who knows, maybe some poor soul out there plans to compile standalone Nashorn for Java 11?

All tests, including the 262 test suite, pass after these changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258147](https://bugs.openjdk.java.net/browse/JDK-8258147): Modernize Nashorn code


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/nashorn pull/5/head:pull/5`
`$ git checkout pull/5`
