### PR TITLE
8233195: Don't hoist block-scoped variables from dead code

### DIFF
--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/FoldConstants.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/codegen/FoldConstants.java
@@ -195,7 +195,9 @@ final class FoldConstants extends SimpleNodeVisitor implements Loggable {
         deadCodeRoot.accept(new SimpleNodeVisitor() {
             @Override
             public boolean enterVarNode(final VarNode varNode) {
-                statements.add(varNode.setInit(null));
+                if (!varNode.isBlockScoped()) {
+                    statements.add(varNode.setInit(null));
+                }
                 return false;
             }
 

--- a/test/nashorn/script/basic/es6/JDK-8233195.js
+++ b/test/nashorn/script/basic/es6/JDK-8233195.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * JDK-8233195: SyntaxError in constant folding with block scoped vars
+ *
+ * @test
+ * @run
+ * @option --language=es6
+ */
+
+function x() {
+    if (true) { throw "test"; } { let x = "1"; } { let x = 2; }
+}
+
+try {
+    x();
+} catch(e) {
+    print("Caught: " + e);
+}

--- a/test/nashorn/script/basic/es6/JDK-8233195.js.EXPECTED
+++ b/test/nashorn/script/basic/es6/JDK-8233195.js.EXPECTED
@@ -1,0 +1,1 @@
+Caught: test


### PR DESCRIPTION
Fixes the bug where dead code removal would erroneously hoist block scoped variable declarations into the function scope; that should work for `var`s but not for `let`s and `const`s.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8233195](https://bugs.openjdk.java.net/browse/JDK-8233195): Don't hoist block-scoped variables from dead code


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/nashorn pull/6/head:pull/6`
`$ git checkout pull/6`
