### PR TITLE
8244586: Opportunistic type evaluation should gracefully handle undefined lets and consts

### DIFF
--- a/test/nashorn/script/basic/es6/JDK-8244586.js
+++ b/test/nashorn/script/basic/es6/JDK-8244586.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * JDK-8244586: UnwarrantedOptimismException corrupts scope of nested functions with eval
+ *
+ * @test
+ * @run
+ * @option --language=es6
+ */
+
+function fn() { 
+    const object1 = { "name": "Pepa" }; 
+    print(object1.name); 
+    const descriptor1 = Object.getOwnPropertyDescriptor(object1, 'name'); 
+    print(descriptor1.configurable); 
+    print(eval("3+1")); 
+} 
+fn(); 

--- a/test/nashorn/script/basic/es6/JDK-8244586.js.EXPECTED
+++ b/test/nashorn/script/basic/es6/JDK-8244586.js.EXPECTED
@@ -1,0 +1,3 @@
+Pepa
+true
+4


### PR DESCRIPTION
Opportunistic type evaluation should gracefully handle undefined lets and consts

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244586](https://bugs.openjdk.java.net/browse/JDK-8244586): Opportunistic type evaluation should gracefully handle undefined lets and consts


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/nashorn pull/7/head:pull/7`
`$ git checkout pull/7`
