### PR TITLE
8258216: Allow Nashorn to operate when not loaded as a JPMS module

### DIFF
--- a/make/nashorn/build.xml
+++ b/make/nashorn/build.xml
@@ -242,6 +242,8 @@
           <attribute name="Implementation-Version" value="${nashorn.version}"/>
         </section>
       </manifest>
+      <service type="javax.script.ScriptEngineFactory" provider="org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory"/>
+      <service type="jdk.dynalink.linker.GuardingDynamicLinkerExporter" provider="org.openjdk.nashorn.api.linker.NashornLinkerExporter"/>
     </jar>
   </target>
 

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/NashornLoader.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/NashornLoader.java
@@ -58,7 +58,6 @@ abstract class NashornLoader extends SecureClassLoader {
     protected static final String SCRIPTS_PKG_INTERNAL        = "org/openjdk/nashorn/internal/scripts";
 
     static final Module NASHORN_MODULE = Context.class.getModule();
-    static final boolean modular = NASHORN_MODULE.getName() != null;
 
     private static final Permission[] SCRIPT_PERMISSIONS;
 
@@ -119,6 +118,14 @@ abstract class NashornLoader extends SecureClassLoader {
                 InvocationTargetException ex) {
             throw new RuntimeException(ex);
         }
+    }
+
+    static boolean isInNamedModule() {
+        // True if Nashorn is loaded as a JPMS module (typically, added to
+        // --module-path); false if it is loaded through classpath into an
+        // unnamed module. There are modular execution aspects that need to
+        // be taken care of when Nashorn is used as a JPMS module.
+        return NASHORN_MODULE.isNamed();
     }
 
     protected static void checkPackageAccess(final String name) {

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/NashornLoader.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/NashornLoader.java
@@ -58,6 +58,7 @@ abstract class NashornLoader extends SecureClassLoader {
     protected static final String SCRIPTS_PKG_INTERNAL        = "org/openjdk/nashorn/internal/scripts";
 
     static final Module NASHORN_MODULE = Context.class.getModule();
+    static final boolean modular = NASHORN_MODULE.getName() != null;
 
     private static final Permission[] SCRIPT_PERMISSIONS;
 

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptLoader.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptLoader.java
@@ -53,18 +53,22 @@ final class ScriptLoader extends NashornLoader {
         super(context.getStructLoader());
         this.context = context;
 
-        // new scripts module, it's specific exports and read-edges
-        scriptModule = createModule("org.openjdk.nashorn.scripts");
+        if (modular) {
+            // new scripts module, it's specific exports and read-edges
+            scriptModule = createModule("org.openjdk.nashorn.scripts");
 
-        // specific exports from nashorn to new scripts module
-        NASHORN_MODULE.addExports(OBJECTS_PKG, scriptModule);
-        NASHORN_MODULE.addExports(RUNTIME_PKG, scriptModule);
-        NASHORN_MODULE.addExports(RUNTIME_ARRAYS_PKG, scriptModule);
-        NASHORN_MODULE.addExports(RUNTIME_LINKER_PKG, scriptModule);
-        NASHORN_MODULE.addExports(SCRIPTS_PKG, scriptModule);
+            // specific exports from nashorn to new scripts module
+            NASHORN_MODULE.addExports(OBJECTS_PKG, scriptModule);
+            NASHORN_MODULE.addExports(RUNTIME_PKG, scriptModule);
+            NASHORN_MODULE.addExports(RUNTIME_ARRAYS_PKG, scriptModule);
+            NASHORN_MODULE.addExports(RUNTIME_LINKER_PKG, scriptModule);
+            NASHORN_MODULE.addExports(SCRIPTS_PKG, scriptModule);
 
-        // nashorn needs to read scripts module methods,fields
-        NASHORN_MODULE.addReads(scriptModule);
+            // nashorn needs to read scripts module methods,fields
+            NASHORN_MODULE.addReads(scriptModule);
+        } else {
+            scriptModule = null;
+        }
     }
 
     private Module createModule(final String moduleName) {
@@ -95,7 +99,7 @@ final class ScriptLoader extends NashornLoader {
     protected Class<?> loadClass(final String name, final boolean resolve) throws ClassNotFoundException {
         checkPackageAccess(name);
         final Class<?> cl = super.loadClass(name, resolve);
-        if (!structureAccessAdded) {
+        if (!structureAccessAdded && modular) {
             final StructureLoader structLoader = context.getStructLoader();
             if (cl.getClassLoader() == structLoader) {
                 structureAccessAdded = true;

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptLoader.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptLoader.java
@@ -53,7 +53,7 @@ final class ScriptLoader extends NashornLoader {
         super(context.getStructLoader());
         this.context = context;
 
-        if (modular) {
+        if (isInNamedModule()) {
             // new scripts module, it's specific exports and read-edges
             scriptModule = createModule();
 
@@ -99,7 +99,7 @@ final class ScriptLoader extends NashornLoader {
     protected Class<?> loadClass(final String name, final boolean resolve) throws ClassNotFoundException {
         checkPackageAccess(name);
         final Class<?> cl = super.loadClass(name, resolve);
-        if (!structureAccessAdded && modular) {
+        if (!structureAccessAdded && isInNamedModule()) {
             final StructureLoader structLoader = context.getStructLoader();
             if (cl.getClassLoader() == structLoader) {
                 structureAccessAdded = true;

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptLoader.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptLoader.java
@@ -55,7 +55,7 @@ final class ScriptLoader extends NashornLoader {
 
         if (modular) {
             // new scripts module, it's specific exports and read-edges
-            scriptModule = createModule("org.openjdk.nashorn.scripts");
+            scriptModule = createModule();
 
             // specific exports from nashorn to new scripts module
             NASHORN_MODULE.addExports(OBJECTS_PKG, scriptModule);
@@ -71,10 +71,10 @@ final class ScriptLoader extends NashornLoader {
         }
     }
 
-    private Module createModule(final String moduleName) {
+    private Module createModule() {
         final Module structMod = context.getStructLoader().getModule();
         final ModuleDescriptor.Builder builder =
-            ModuleDescriptor.newModule(moduleName, Set.of(Modifier.SYNTHETIC))
+            ModuleDescriptor.newModule("org.openjdk.nashorn.scripts", Set.of(Modifier.SYNTHETIC))
                     .requires("java.logging")
                     .requires(NASHORN_MODULE.getName())
                     .requires(structMod.getName())

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/StructureLoader.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/StructureLoader.java
@@ -53,7 +53,7 @@ final class StructureLoader extends NashornLoader {
 
         if (modular) {
             // new structures module, it's exports, read edges
-            structuresModule = createModule("org.openjdk.nashorn.structures");
+            structuresModule = createModule();
 
             // specific exports from nashorn to the structures module
             NASHORN_MODULE.addExports(SCRIPTS_PKG, structuresModule);
@@ -66,9 +66,9 @@ final class StructureLoader extends NashornLoader {
         }
     }
 
-    private Module createModule(final String moduleName) {
+    private Module createModule() {
         final ModuleDescriptor descriptor =
-            ModuleDescriptor.newModule(moduleName, Set.of(Modifier.SYNTHETIC))
+            ModuleDescriptor.newModule("org.openjdk.nashorn.structures", Set.of(Modifier.SYNTHETIC))
                             .requires(NASHORN_MODULE.getName())
                             .packages(Set.of(SCRIPTS_PKG))
                             .build();

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/StructureLoader.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/StructureLoader.java
@@ -51,15 +51,19 @@ final class StructureLoader extends NashornLoader {
     StructureLoader(final ClassLoader parent) {
         super(parent);
 
-        // new structures module, it's exports, read edges
-        structuresModule = createModule("org.openjdk.nashorn.structures");
+        if (modular) {
+            // new structures module, it's exports, read edges
+            structuresModule = createModule("org.openjdk.nashorn.structures");
 
-        // specific exports from nashorn to the structures module
-        NASHORN_MODULE.addExports(SCRIPTS_PKG, structuresModule);
-        NASHORN_MODULE.addExports(RUNTIME_PKG, structuresModule);
+            // specific exports from nashorn to the structures module
+            NASHORN_MODULE.addExports(SCRIPTS_PKG, structuresModule);
+            NASHORN_MODULE.addExports(RUNTIME_PKG, structuresModule);
 
-        // nashorn has to read fields from classes of the new module
-        NASHORN_MODULE.addReads(structuresModule);
+            // nashorn has to read fields from classes of the new module
+            NASHORN_MODULE.addReads(structuresModule);
+        } else {
+            structuresModule = null;
+        }
     }
 
     private Module createModule(final String moduleName) {

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/StructureLoader.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/StructureLoader.java
@@ -51,7 +51,7 @@ final class StructureLoader extends NashornLoader {
     StructureLoader(final ClassLoader parent) {
         super(parent);
 
-        if (modular) {
+        if (isInNamedModule()) {
             // new structures module, it's exports, read edges
             structuresModule = createModule();
 


### PR DESCRIPTION
Allow Nashorn to operate when not loaded as a JPMS module

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8258216](https://bugs.openjdk.java.net/browse/JDK-8258216): Allow Nashorn to operate when not loaded as a JPMS module


### Download
`$ git fetch https://git.openjdk.java.net/nashorn pull/9/head:pull/9`
`$ git checkout pull/9`
