### PR TITLE
8258787: ScriptEngineFactory.getOutputStatement neither quotes nor escapes its argument

### DIFF
--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/api/scripting/NashornScriptEngineFactory.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/api/scripting/NashornScriptEngineFactory.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Objects;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineFactory;
+import org.openjdk.nashorn.internal.parser.JSONParser;
 import org.openjdk.nashorn.internal.runtime.Context;
 import org.openjdk.nashorn.internal.runtime.Version;
 
@@ -103,7 +104,7 @@ public final class NashornScriptEngineFactory implements ScriptEngineFactory {
 
     @Override
     public String getOutputStatement(final String toDisplay) {
-        return "print(" + toDisplay + ")";
+        return "print(" + JSONParser.quote(toDisplay) + ")";
     }
 
     @Override

--- a/test/nashorn/src/org/openjdk/nashorn/api/scripting/test/ScriptEngineTest.java
+++ b/test/nashorn/src/org/openjdk/nashorn/api/scripting/test/ScriptEngineTest.java
@@ -132,7 +132,8 @@ public class ScriptEngineTest {
         assertEquals(fac.getParameter(ScriptEngine.NAME), "javascript");
         assertEquals(fac.getLanguageVersion(), "ECMA - 262 Edition 5.1");
         assertEquals(fac.getEngineName(), "Oracle Nashorn");
-        assertEquals(fac.getOutputStatement("context"), "print(context)");
+        assertEquals(fac.getOutputStatement("context"), "print(\"context\")");
+        assertEquals(fac.getOutputStatement("\"\\\b\f\n\r\t"), "print(\"\\\"\\\\\\b\\f\\n\\r\\t\")");
         assertEquals(fac.getProgram("print('hello')", "print('world')"), "print('hello');print('world');");
         assertEquals(fac.getParameter(ScriptEngine.NAME), "javascript");
 


### PR DESCRIPTION
`ScriptEngineFactory.getOutputStatement` neither quotes nor escapes its argument. It is fundamentally broken this way.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8258787](https://bugs.openjdk.java.net/browse/JDK-8258787): ScriptEngineFactory.getOutputStatement neither quotes nor escapes its argument


### Download
`$ git fetch https://git.openjdk.java.net/nashorn pull/11/head:pull/11`
`$ git checkout pull/11`
