### PR TITLE
8240298: Array.prototype.pop, push, and reverse didn't call ToObject on their argument

### DIFF
--- a/test/nashorn/script/basic/JDK-8240298.js
+++ b/test/nashorn/script/basic/JDK-8240298.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * JDK-8240298: Array.prototype.{push|pop|reverse} must call ToObject on their argument
+ *
+ * @test
+ * @run
+ */
+
+print(typeof Array.prototype.pop.call(false) == "undefined")
+print(Array.prototype.push.call(false) == 0)
+print(Array.prototype.push.call(false, 2) == 1)
+print(Array.prototype.push.call(false, 2, 4, 6) == 3)
+var x = Array.prototype.reverse.call(false)
+print(typeof x == "object")
+print(x.toString() == "false")

--- a/test/nashorn/script/basic/JDK-8240298.js.EXPECTED
+++ b/test/nashorn/script/basic/JDK-8240298.js.EXPECTED
@@ -1,0 +1,6 @@
+true
+true
+true
+true
+true
+true


### PR DESCRIPTION
Array.prototype.pop, push, and reverse didn't call ToObject on their argument. I suggest reviewing with [ignoring whitespace](https://github.com/openjdk/nashorn/pull/12/files?w=1) to lessen the impact of changed indentation because of removed try/catch blocks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8240298](https://bugs.openjdk.java.net/browse/JDK-8240298): Array.prototype.pop, push, and reverse didn't call ToObject on their argument


### Download
`$ git fetch https://git.openjdk.java.net/nashorn pull/12/head:pull/12`
`$ git checkout pull/12`
