### PR TITLE
8265691: Some Object constructor methods aren't ES6 compliant

### DIFF
--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/Global.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/Global.java
@@ -1163,7 +1163,7 @@ public final class Global extends Scope {
     public Global(final Context context) {
         super(checkAndGetMap(context));
         this.context = context;
-        this.lexicalScope = context.getEnv()._es6 ? new LexicalScope(this) : null;
+        this.lexicalScope = isES6() ? new LexicalScope(this) : null;
     }
 
     /**
@@ -2392,12 +2392,16 @@ public final class Global extends Scope {
         }
     }
 
+    public boolean isES6() {
+        return context.getEnv()._es6;
+    }
+
     /**
      * Return the ES6 global scope for lexically declared bindings.
      * @return the ES6 lexical global scope.
      */
     public final ScriptObject getLexicalScope() {
-        assert context.getEnv()._es6;
+        assert isES6();
         return lexicalScope;
     }
 
@@ -2408,7 +2412,7 @@ public final class Global extends Scope {
         PropertyMap lexicalMap = null;
         boolean hasLexicalDefinitions = false;
 
-        if (context.getEnv()._es6) {
+        if (isES6()) {
             lexScope = (LexicalScope) getLexicalScope();
             lexicalMap = lexScope.getMap();
 
@@ -2470,7 +2474,7 @@ public final class Global extends Scope {
         // We therefore check if the invocation does already have a switchpoint and the property is non-inherited,
         // assuming this only applies to global constants. If other non-inherited properties will
         // start using switchpoints some time in the future we'll have to revisit this.
-        if (isScope && context.getEnv()._es6 && (invocation.getSwitchPoints() == null || !hasOwnProperty(name))) {
+        if (isScope && isES6() && (invocation.getSwitchPoints() == null || !hasOwnProperty(name))) {
             return invocation.addSwitchPoint(getLexicalScopeSwitchPoint());
         }
 
@@ -2501,7 +2505,7 @@ public final class Global extends Scope {
 
         final GuardedInvocation invocation = super.findSetMethod(desc, request);
 
-        if (isScope && context.getEnv()._es6) {
+        if (isScope && isES6()) {
             return invocation.addSwitchPoint(getLexicalScopeSwitchPoint());
         }
 

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeObject.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/NativeObject.java
@@ -247,9 +247,16 @@ public final class NativeObject {
             return new NativeArray(((ScriptObject)obj).getOwnKeys(true));
         } else if (obj instanceof ScriptObjectMirror) {
             return new NativeArray(((ScriptObjectMirror)obj).getOwnKeys(true));
-        } else {
-            throw notAnObject(obj);
         }
+        final var global = Global.instance();
+        if (global.isES6()) {
+            final var obj2 = JSType.toScriptObject(global, obj);
+            if (obj2 instanceof ScriptObject) {
+                return new NativeArray(((ScriptObject)obj2).getOwnKeys(true));
+            }
+            return new NativeArray();
+        }
+        throw notAnObject(obj);
     }
 
     /**
@@ -261,12 +268,12 @@ public final class NativeObject {
      */
     @Function(attributes = Attribute.NOT_ENUMERABLE, where = Where.CONSTRUCTOR)
     public static ScriptObject getOwnPropertySymbols(final Object self, final Object obj) {
-        if (obj instanceof ScriptObject) {
-            return new NativeArray(((ScriptObject)obj).getOwnSymbols(true));
-        } else {
-            // TODO: we don't support this on ScriptObjectMirror objects yet
-            throw notAnObject(obj);
+        final var obj2 = JSType.toScriptObject(obj);
+        if (obj2 instanceof ScriptObject) {
+            return new NativeArray(((ScriptObject)obj2).getOwnSymbols(true));
         }
+        // TODO: we don't support this on ScriptObjectMirror objects yet
+        return new NativeArray();
     }
 
     /**
@@ -346,6 +353,8 @@ public final class NativeObject {
             return ((ScriptObject)obj).seal();
         } else if (obj instanceof ScriptObjectMirror) {
             return ((ScriptObjectMirror)obj).seal();
+        } else if (isES6()) {
+            return obj;
         } else {
             throw notAnObject(obj);
         }
@@ -365,9 +374,15 @@ public final class NativeObject {
             return ((ScriptObject)obj).freeze();
         } else if (obj instanceof ScriptObjectMirror) {
             return ((ScriptObjectMirror)obj).freeze();
+        } else if (isES6()) {
+            return obj;
         } else {
             throw notAnObject(obj);
         }
+    }
+
+    private static boolean isES6() {
+        return Global.instance().isES6();
     }
 
     /**
@@ -383,6 +398,8 @@ public final class NativeObject {
             return ((ScriptObject)obj).preventExtensions();
         } else if (obj instanceof ScriptObjectMirror) {
             return ((ScriptObjectMirror)obj).preventExtensions();
+        } else if (isES6()) {
+            return obj;
         } else {
             throw notAnObject(obj);
         }
@@ -401,6 +418,8 @@ public final class NativeObject {
             return ((ScriptObject)obj).isSealed();
         } else if (obj instanceof ScriptObjectMirror) {
             return ((ScriptObjectMirror)obj).isSealed();
+        } else if (isES6()) {
+            return true;
         } else {
             throw notAnObject(obj);
         }
@@ -419,6 +438,8 @@ public final class NativeObject {
             return ((ScriptObject)obj).isFrozen();
         } else if (obj instanceof ScriptObjectMirror) {
             return ((ScriptObjectMirror)obj).isFrozen();
+        } else if (isES6()) {
+            return true;
         } else {
             throw notAnObject(obj);
         }
@@ -437,6 +458,8 @@ public final class NativeObject {
             return ((ScriptObject)obj).isExtensible();
         } else if (obj instanceof ScriptObjectMirror) {
             return ((ScriptObjectMirror)obj).isExtensible();
+        } else if (isES6()) {
+            return false;
         } else {
             throw notAnObject(obj);
         }

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/parser/Parser.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/parser/Parser.java
@@ -313,7 +313,7 @@ public class Parser extends AbstractParser implements Loggable {
 
         try {
             stream = new TokenStream();
-            lexer  = new Lexer(source, startPos, len, stream, scripting && !env._no_syntax_extensions, env._es6, reparsedFunction != null);
+            lexer  = new Lexer(source, startPos, len, stream, scripting && !env._no_syntax_extensions, isES6(), reparsedFunction != null);
             lexer.line = lexer.pendingLine = lineOffset + 1;
             line = lineOffset;
 
@@ -349,7 +349,7 @@ public class Parser extends AbstractParser implements Loggable {
     public FunctionNode parseModule(final String moduleName, final int startPos, final int len) {
         try {
             stream = new TokenStream();
-            lexer  = new Lexer(source, startPos, len, stream, scripting && !env._no_syntax_extensions, env._es6, reparsedFunction != null);
+            lexer  = new Lexer(source, startPos, len, stream, scripting && !env._no_syntax_extensions, isES6(), reparsedFunction != null);
             lexer.line = lexer.pendingLine = lineOffset + 1;
             line = lineOffset;
 
@@ -383,7 +383,7 @@ public class Parser extends AbstractParser implements Loggable {
     public void parseFormalParameterList() {
         try {
             stream = new TokenStream();
-            lexer  = new Lexer(source, stream, scripting && !env._no_syntax_extensions, env._es6);
+            lexer  = new Lexer(source, stream, scripting && !env._no_syntax_extensions, isES6());
 
             scanFirstToken();
 
@@ -403,7 +403,7 @@ public class Parser extends AbstractParser implements Loggable {
     public void parseFunctionBody() {
         try {
             stream = new TokenStream();
-            lexer  = new Lexer(source, stream, scripting && !env._no_syntax_extensions, env._es6);
+            lexer  = new Lexer(source, stream, scripting && !env._no_syntax_extensions, isES6());
             final int functionLine = line;
 
             scanFirstToken();
@@ -664,7 +664,7 @@ public class Parser extends AbstractParser implements Loggable {
     }
 
     private boolean useBlockScope() {
-        return env._es6;
+        return isES6();
     }
 
     private boolean isES6() {
@@ -1984,7 +1984,7 @@ public class Parser extends AbstractParser implements Loggable {
                 break;
 
             case IDENT:
-                if (env._es6 && "of".equals(getValue())) {
+                if (isES6() && "of".equals(getValue())) {
                     isForOf = true;
                     // fall through
                 } else {
@@ -4260,7 +4260,7 @@ public class Parser extends AbstractParser implements Loggable {
         }
 
         stream.reset();
-        lexer = parserState.createLexer(source, lexer, stream, scripting && !env._no_syntax_extensions, env._es6);
+        lexer = parserState.createLexer(source, lexer, stream, scripting && !env._no_syntax_extensions, isES6());
         line = parserState.line;
         linePosition = parserState.linePosition;
         // Doesn't really matter, but it's safe to treat it as if there were a semicolon before


### PR DESCRIPTION
`Object` constructor methods `freeze`, `isFrozen`, `seal`, `isSealed`, `preventExtensions`, `isExtensible`, `getOwnPropertyNames`, `getOwnPropertySymbols` operate under ES5 semantics even under ES6 language when their argument is not an object.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8265691](https://bugs.openjdk.java.net/browse/JDK-8265691): Some Object constructor methods aren't ES6 compliant


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/nashorn pull/14/head:pull/14` \
`$ git checkout pull/14`

Update a local copy of the PR: \
`$ git checkout pull/14` \
`$ git pull https://git.openjdk.java.net/nashorn pull/14/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14`

View PR using the GUI difftool: \
`$ git pr show -t 14`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/nashorn/pull/14.diff">https://git.openjdk.java.net/nashorn/pull/14.diff</a>

</details>
