### PR TITLE
8261926: Attempt to access property/element of a Java method results in AssertionError: unknown call type

### DIFF
--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/Bootstrap.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/linker/Bootstrap.java
@@ -472,7 +472,7 @@ public final class Bootstrap {
     }
 
     private static MethodHandle createMissingMemberHandler(
-            final LinkRequest linkRequest, final LinkerServices linkerServices) throws Exception {
+            final LinkRequest linkRequest, final LinkerServices linkerServices) {
         if (BrowserJSObjectLinker.canLinkTypeStatic(linkRequest.getReceiver().getClass())) {
             // Don't create missing member handlers for the browser JS objects as they
             // have their own logic.

--- a/test/nashorn/script/basic/JDK-8261926.js
+++ b/test/nashorn/script/basic/JDK-8261926.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * JDK-8261926: Attempt to access property/element of a Java method results in AssertionError: unknown call type
+ *
+ * @test
+ * @run
+ */
+
+var v = java.lang.String.valueOf
+
+isVCallUndefined()
+v.call = 1
+isVCallUndefined()
+
+function isVCallUndefined() {
+  Assert.assertEquals(typeof(v.call), "undefined")
+}
+
+function mustFailWithTypeError(f){
+  try {
+    f()
+    Assert.fail("Did not fail with TypeError")
+  } catch (e) {
+    if (!(e instanceof TypeError)) {
+      Assert.fail("Should have failed with TypeError, it was instead " + e)
+    }
+  }
+}
+
+(function() {
+  "use strict";
+  Assert.assertEquals(typeof(v.call), "undefined")
+  mustFailWithTypeError(function() { 
+    v.call = 1
+  })
+  isVCallUndefined()
+  Assert.assertTrue(delete v.call)  
+})()
+
+Assert.assertTrue(delete v.call)
+isVCallUndefined()


### PR DESCRIPTION
Attempt to access property/element of a Java method results in AssertionError: unknown call type

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8261926](https://bugs.openjdk.java.net/browse/JDK-8261926): Attempt to access property/element of a Java method results in AssertionError: unknown call type


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/nashorn pull/15/head:pull/15` \
`$ git checkout pull/15`

Update a local copy of the PR: \
`$ git checkout pull/15` \
`$ git pull https://git.openjdk.java.net/nashorn pull/15/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15`

View PR using the GUI difftool: \
`$ git pr show -t 15`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/nashorn/pull/15.diff">https://git.openjdk.java.net/nashorn/pull/15.diff</a>

</details>
