### PR TITLE
8294560: assertion raised in newBuiltinSwitchPoint

### DIFF
--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/Global.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/Global.java
@@ -2945,10 +2945,7 @@ public final class Global extends Scope {
      * @param func builtin script object
      */
     private void tagBuiltinProperties(final String name, final ScriptObject func) {
-        SwitchPoint sp = context.getBuiltinSwitchPoint(name);
-        if (sp == null) {
-            sp = context.newBuiltinSwitchPoint(name);
-        }
+        final SwitchPoint sp = context.getBuiltinSwitchPoint(name);
 
         //get all builtin properties in this builtin object and register switchpoints keyed on the propery name,
         //one overwrite destroys all for now, e.g. Function.prototype.apply = 17; also destroys Function.prototype.call etc

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/Context.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/Context.java
@@ -180,7 +180,7 @@ public final class Context {
      * ever needs this, given the very rare occurrence of swapping out only parts of
      * a builtin v.s. the entire builtin object
      */
-    private final Map<String, SwitchPoint> builtinSwitchPoints = new HashMap<>();
+    private final Map<String, SwitchPoint> builtinSwitchPoints = new ConcurrentHashMap<>();
 
     /* Force DebuggerSupport to be loaded. */
     static {
@@ -1729,24 +1729,13 @@ public final class Context {
     }
 
     /**
-     * Create a new builtin switchpoint and return it
+     * Return the builtin switchpoint for a particular key name. A new switchpoint
+     * is atomically created if it doesn't exist yet.
      * @param name key name
-     * @return new builtin switchpoint
-     */
-    public SwitchPoint newBuiltinSwitchPoint(final String name) {
-        assert builtinSwitchPoints.get(name) == null;
-        final SwitchPoint sp = new BuiltinSwitchPoint();
-        builtinSwitchPoints.put(name, sp);
-        return sp;
-    }
-
-    /**
-     * Return the builtin switchpoint for a particular key name
-     * @param name key name
-     * @return builtin switchpoint or null if none
+     * @return builtin switchpoint
      */
     public SwitchPoint getBuiltinSwitchPoint(final String name) {
-        return builtinSwitchPoints.get(name);
+        return builtinSwitchPoints.computeIfAbsent(name, n -> new BuiltinSwitchPoint());
     }
 
     private static ClassLoader createModuleLoader(final ClassLoader cl,

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptRuntime.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptRuntime.java
@@ -1161,7 +1161,6 @@ public final class ScriptRuntime {
     public static void invalidateReservedBuiltinName(final String name) {
         final Context context = Context.getContextTrusted();
         final SwitchPoint sp = context.getBuiltinSwitchPoint(name);
-        assert sp != null;
         context.getLogger(ApplySpecialization.class).info("Overwrote special name '" + name +"' - invalidating switchpoint");
         SwitchPoint.invalidateAll(new SwitchPoint[] { sp });
     }


### PR DESCRIPTION
Fixes the problem by making switchpoint creation safe under concurrent use.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8294560](https://bugs.openjdk.org/browse/JDK-8294560): assertion raised in newBuiltinSwitchPoint


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/nashorn pull/18/head:pull/18` \
`$ git checkout pull/18`

Update a local copy of the PR: \
`$ git checkout pull/18` \
`$ git pull https://git.openjdk.org/nashorn pull/18/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18`

View PR using the GUI difftool: \
`$ git pr show -t 18`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/nashorn/pull/18.diff">https://git.openjdk.org/nashorn/pull/18.diff</a>

</details>
