### PR TITLE
8343449: Nashorn method handle debug logging breaks with log4j-jul

### DIFF
--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/lookup/MethodHandleFactory.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/lookup/MethodHandleFactory.java
@@ -370,9 +370,8 @@ public final class MethodHandleFactory {
 
         public MethodHandle debug(final MethodHandle master, final String str, final Object... args) {
             // The static `log` field can be `null` if the `MethodHandlerFactory` class has not been initialized yet.
-            if (PRINT_STACKTRACE) {
-                stacktrace(log);
-            }
+            // Both these methods are null-safe
+            stacktrace(log);
             return addDebugPrintout(log, Level.INFO, master, Integer.MAX_VALUE, false, str + ' ' + describe(args));
         }
 

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/lookup/MethodHandleFactory.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/lookup/MethodHandleFactory.java
@@ -100,6 +100,19 @@ public final class MethodHandleFactory {
         return obj.toString();
     }
 
+    private static final MethodHandle TRACE;
+    private static final MethodHandle TRACE_RETURN;
+    private static final MethodHandle TRACE_RETURN_VOID;
+    static {
+        try {
+            TRACE = LOOKUP.findStatic(MethodHandleFactory.class, "traceArgs",   MethodType.methodType(void.class, DebugLogger.class, String.class, int.class, Object[].class));
+            TRACE_RETURN = LOOKUP.findStatic(MethodHandleFactory.class, "traceReturn", MethodType.methodType(Object.class, DebugLogger.class, Object.class));
+            TRACE_RETURN_VOID = LOOKUP.findStatic(MethodHandleFactory.class, "traceReturnVoid", MethodType.methodType(void.class, DebugLogger.class));
+        } catch (NoSuchMethodException | IllegalAccessException e) {
+            throw new LookupException(e);
+        }
+    }
+
     private static final MethodHandleFunctionality FUNC = new StandardMethodHandleFunctionality();
     private static final boolean PRINT_STACKTRACE = Options.getBooleanProperty("nashorn.methodhandles.debug.stacktrace");
 
@@ -110,10 +123,6 @@ public final class MethodHandleFactory {
     public static MethodHandleFunctionality getFunctionality() {
         return FUNC;
     }
-
-    private static final MethodHandle TRACE             = FUNC.findStatic(LOOKUP, MethodHandleFactory.class, "traceArgs",   MethodType.methodType(void.class, DebugLogger.class, String.class, int.class, Object[].class));
-    private static final MethodHandle TRACE_RETURN      = FUNC.findStatic(LOOKUP, MethodHandleFactory.class, "traceReturn", MethodType.methodType(Object.class, DebugLogger.class, Object.class));
-    private static final MethodHandle TRACE_RETURN_VOID = FUNC.findStatic(LOOKUP, MethodHandleFactory.class, "traceReturnVoid", MethodType.methodType(void.class, DebugLogger.class));
 
     private static final String VOID_TAG = "[VOID]";
 


### PR DESCRIPTION
The `MethodHandleFactory` and especially its `FUNC` static field are heavily used during the static initialization process.

To prevent nullability problems in the static `MethodHandleFactory` fields, `StandardMethodHandleFunctionality` relies on `DebugLogger.DISABLED_LOGGER.isEnabled()` being `false` during the initialization process.
If this assumption is true, static `MethodHandleFactory` fields will not be accessed by `StandardMethodHandleFunctionality`.
If this assumption, however, fails (as described in apache/logging-log4j2#3119) the static initialization fails with some unforeseen NPEs.

We improve the above machanism by:

- Replacing the `StandardMethodHandleFunctionality.log` field with a static field in the top level class.
- The new `log` field is placed last, so it holds the value `null` until the end of static initialization.
- All the usages of the `log` fields are checked to ensure that they contain a null-check.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8343449](https://bugs.openjdk.org/browse/JDK-8343449): Nashorn method handle debug logging breaks with log4j-jul (**Bug** - P4)


### Reviewers
 * [Attila Szegedi](https://openjdk.org/census#attila) (@szegedi - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/nashorn.git pull/19/head:pull/19` \
`$ git checkout pull/19`

Update a local copy of the PR: \
`$ git checkout pull/19` \
`$ git pull https://git.openjdk.org/nashorn.git pull/19/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19`

View PR using the GUI difftool: \
`$ git pr show -t 19`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/nashorn/pull/19.diff">https://git.openjdk.org/nashorn/pull/19.diff</a>

</details>
