### PR TITLE
8346848: Eliminate compilation warnings with Java 21

### DIFF
--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/Block.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/Block.java
@@ -46,9 +46,11 @@ public class Block extends Node implements BreakableNode, Terminal, Flags<Block>
     private static final long serialVersionUID = 1L;
 
     /** List of statements */
+    @SuppressWarnings("serial")
     protected final List<Statement> statements;
 
     /** Symbol table - keys must be returned in the order they were put in. */
+    @SuppressWarnings("serial")
     protected final Map<String, Symbol> symbols;
 
     /** Entry label. */

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/CallNode.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/CallNode.java
@@ -46,6 +46,7 @@ public final class CallNode extends LexicalContextExpression implements Optimist
     private final Expression function;
 
     /** Call arguments. */
+    @SuppressWarnings("serial")
     private final List<Expression> args;
 
     /** Is this a "new" operation */
@@ -67,6 +68,7 @@ public final class CallNode extends LexicalContextExpression implements Optimist
      */
     public static class EvalArgs implements Serializable {
         private static final long serialVersionUID = 1L;
+        @SuppressWarnings("serial")
         private final List<Expression> args;
 
         /** location string for the eval call */

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/ClassNode.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/ClassNode.java
@@ -40,6 +40,7 @@ public class ClassNode extends Expression {
     private final IdentNode ident;
     private final Expression classHeritage;
     private final PropertyNode constructor;
+    @SuppressWarnings("serial")
     private final List<PropertyNode> classElements;
     private final int line;
     private final boolean isStatement;

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/ExpressionList.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/ExpressionList.java
@@ -37,6 +37,7 @@ import org.openjdk.nashorn.internal.ir.visitor.NodeVisitor;
 public final class ExpressionList extends Expression {
     private static final long serialVersionUID = 1L;
 
+    @SuppressWarnings("serial")
     private final List<Expression> expressions;
 
     /**

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/FunctionNode.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/FunctionNode.java
@@ -32,6 +32,7 @@ import static org.openjdk.nashorn.internal.runtime.linker.NashornCallSiteDescrip
 import static org.openjdk.nashorn.internal.runtime.linker.NashornCallSiteDescriptor.CALLSITE_TRACE_MISSES;
 import static org.openjdk.nashorn.internal.runtime.linker.NashornCallSiteDescriptor.CALLSITE_TRACE_VALUES;
 
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -86,7 +87,7 @@ public final class FunctionNode extends LexicalContextExpression implements Flag
      * Opaque object representing parser state at the end of the function. Used when reparsing outer functions
      * to skip parsing inner functions.
      */
-    private final Object endParserState;
+    private final Serializable endParserState;
 
     /** External function identifier. */
     @Ignore
@@ -105,9 +106,11 @@ public final class FunctionNode extends LexicalContextExpression implements Flag
     private final Kind kind;
 
     /** List of parameters. */
+    @SuppressWarnings("serial")
     private final List<IdentNode> parameters;
 
     /** Map of ES6 function parameter expressions. */
+    @SuppressWarnings("serial")
     private final Map<IdentNode, Expression> parameterExpressions;
 
     /** First token of function. **/
@@ -336,7 +339,7 @@ public final class FunctionNode extends LexicalContextExpression implements Flag
         final FunctionNode.Kind kind,
         final int flags,
         final Block body,
-        final Object endParserState,
+        final Serializable endParserState,
         final Module module,
         final int debugFlags) {
         super(token, finish);
@@ -364,7 +367,7 @@ public final class FunctionNode extends LexicalContextExpression implements Flag
     private FunctionNode(
         final FunctionNode functionNode,
         final long lastToken,
-        final Object endParserState,
+        final Serializable endParserState,
         final int flags,
         final String name,
         final Type returnType,

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/LiteralNode.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/LiteralNode.java
@@ -25,6 +25,7 @@
 
 package org.openjdk.nashorn.internal.ir;
 
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -47,7 +48,7 @@ import org.openjdk.nashorn.internal.runtime.Undefined;
  * @param <T> the literal type
  */
 @Immutable
-public abstract class LiteralNode<T> extends Expression implements PropertyKey {
+public abstract class LiteralNode<T extends Serializable> extends Expression implements PropertyKey {
     private static final long serialVersionUID = 1L;
 
     /** Literal value */
@@ -262,7 +263,7 @@ public abstract class LiteralNode<T> extends Expression implements PropertyKey {
      *
      * @return the new literal node
      */
-    public static LiteralNode<Object> newInstance(final long token, final int finish) {
+    public static LiteralNode<Serializable> newInstance(final long token, final int finish) {
         return new NullLiteralNode(token, finish);
     }
 
@@ -273,7 +274,7 @@ public abstract class LiteralNode<T> extends Expression implements PropertyKey {
      *
      * @return the new literal node
      */
-    public static LiteralNode<Object> newInstance(final Node parent) {
+    public static LiteralNode<Serializable> newInstance(final Node parent) {
         return new NullLiteralNode(parent.getToken(), parent.getFinish());
     }
 
@@ -282,7 +283,7 @@ public abstract class LiteralNode<T> extends Expression implements PropertyKey {
      *
      * @param <T> the literal type
      */
-    public static class PrimitiveLiteralNode<T> extends LiteralNode<T> {
+    public static class PrimitiveLiteralNode<T extends Serializable> extends LiteralNode<T> {
         private static final long serialVersionUID = 1L;
 
         private PrimitiveLiteralNode(final long token, final int finish, final T value) {
@@ -566,7 +567,7 @@ public abstract class LiteralNode<T> extends Expression implements PropertyKey {
         return objectAsConstant(object) != POSTSET_MARKER;
     }
 
-    private static final class NullLiteralNode extends PrimitiveLiteralNode<Object> {
+    private static final class NullLiteralNode extends PrimitiveLiteralNode<Serializable> {
         private static final long serialVersionUID = 1L;
 
         private NullLiteralNode(final long token, final int finish) {
@@ -604,13 +605,14 @@ public abstract class LiteralNode<T> extends Expression implements PropertyKey {
         private final Type elementType;
 
         /** Preset constant array. */
-        private final Object presets;
+        private final Serializable presets;
 
         /** Indices of array elements requiring computed post sets. */
         private final int[] postsets;
 
         /** Ranges for splitting up large literals in code generation */
         @Ignore
+        @SuppressWarnings("serial")
         private final List<Splittable.SplitRange> splitRanges;
 
         /** Does this array literal have a spread element? */
@@ -630,7 +632,7 @@ public abstract class LiteralNode<T> extends Expression implements PropertyKey {
             static ArrayLiteralNode initialize(final ArrayLiteralNode node) {
                 final Type elementType = computeElementType(node.value);
                 final int[] postsets = computePostsets(node.value);
-                final Object presets = computePresets(node.value, elementType, postsets);
+                final Serializable presets = computePresets(node.value, elementType, postsets);
                 return new ArrayLiteralNode(node, node.value, elementType, postsets, presets, node.splitRanges);
             }
 
@@ -735,7 +737,7 @@ public abstract class LiteralNode<T> extends Expression implements PropertyKey {
                 return array;
             }
 
-            static Object computePresets(final Expression[] value, final Type elementType, final int[] postsets) {
+            static Serializable computePresets(final Expression[] value, final Type elementType, final int[] postsets) {
                 assert !elementType.isUnknown();
                 if (elementType.isInteger()) {
                     return presetIntArray(value, postsets);
@@ -754,7 +756,7 @@ public abstract class LiteralNode<T> extends Expression implements PropertyKey {
          * @param finish  finish
          * @param value   array literal value, a Node array
          */
-        protected ArrayLiteralNode(final long token, final int finish, final Expression[] value) {
+        private ArrayLiteralNode(final long token, final int finish, final Expression[] value) {
             this(token, finish, value, false, false);
         }
 
@@ -767,7 +769,7 @@ public abstract class LiteralNode<T> extends Expression implements PropertyKey {
          * @param hasSpread true if the array has a spread element
          * @param hasTrailingComma true if the array literal has a comma after the last element
          */
-        protected ArrayLiteralNode(final long token, final int finish, final Expression[] value, final boolean hasSpread, final boolean hasTrailingComma) {
+        private ArrayLiteralNode(final long token, final int finish, final Expression[] value, final boolean hasSpread, final boolean hasTrailingComma) {
             super(Token.recast(token, TokenType.ARRAY), finish, value);
             this.elementType = Type.UNKNOWN;
             this.presets     = null;
@@ -781,7 +783,7 @@ public abstract class LiteralNode<T> extends Expression implements PropertyKey {
          * Copy constructor
          * @param node source array literal node
          */
-        private ArrayLiteralNode(final ArrayLiteralNode node, final Expression[] value, final Type elementType, final int[] postsets, final Object presets, final List<Splittable.SplitRange> splitRanges) {
+        private ArrayLiteralNode(final ArrayLiteralNode node, final Expression[] value, final Type elementType, final int[] postsets, final Serializable presets, final List<Splittable.SplitRange> splitRanges) {
             super(node, value);
             this.elementType = elementType;
             this.postsets    = postsets;

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/LocalVariableConversion.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/LocalVariableConversion.java
@@ -25,6 +25,7 @@
 
 package org.openjdk.nashorn.internal.ir;
 
+import java.io.Serializable;
 import org.openjdk.nashorn.internal.codegen.types.Type;
 
 /**
@@ -34,7 +35,9 @@ import org.openjdk.nashorn.internal.codegen.types.Type;
  * that is a head of a linked list of instances.
  * @see JoinPredecessor
  */
-public final class LocalVariableConversion {
+public final class LocalVariableConversion implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     private final Symbol symbol;
     // TODO: maybe introduce a type pair class? These will often be repeated.
     private final Type from;

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/Module.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/Module.java
@@ -25,12 +25,15 @@
 
 package org.openjdk.nashorn.internal.ir;
 
+import java.io.Serializable;
 import java.util.List;
 
 /**
  * ES6 Module information.
  */
-public final class Module {
+
+public final class Module implements Serializable {
+    private static final long serialVersionUID = 1L;
 
     /** The synthetic binding name assigned to export default declarations with unnamed expressions. */
     public static final String DEFAULT_EXPORT_BINDING_NAME = "*default*";
@@ -46,7 +49,9 @@ public final class Module {
      *
      * @see <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-source-text-module-records">es6 modules</a>
      */
-    public static final class ExportEntry {
+    public static final class ExportEntry implements Serializable {
+        private static final long serialVersionUID = 1L;
+
         private final IdentNode exportName;
         private final IdentNode moduleRequest;
         private final IdentNode importName;
@@ -298,10 +303,15 @@ public final class Module {
         }
     }
 
+    @SuppressWarnings("serial")
     private final List<String> requestedModules;
+    @SuppressWarnings("serial")
     private final List<ImportEntry> importEntries;
+    @SuppressWarnings("serial")
     private final List<ExportEntry> localExportEntries;
+    @SuppressWarnings("serial")
     private final List<ExportEntry> indirectExportEntries;
+    @SuppressWarnings("serial")
     private final List<ExportEntry> starExportEntries;
 
     /**

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/ObjectNode.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/ObjectNode.java
@@ -41,10 +41,12 @@ public final class ObjectNode extends Expression implements LexicalContextNode, 
     private static final long serialVersionUID = 1L;
 
     /** Literal elements. */
+    @SuppressWarnings("serial")
     private final List<PropertyNode> elements;
 
     /** Ranges for splitting large literals over multiple compile units in codegen. */
     @Ignore
+    @SuppressWarnings("serial")
     private final List<Splittable.SplitRange> splitRanges;
 
     /**

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/RuntimeNode.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/RuntimeNode.java
@@ -327,6 +327,7 @@ public class RuntimeNode extends Expression {
     private final Request request;
 
     /** Call arguments. */
+    @SuppressWarnings("serial")
     private final List<Expression> args;
 
     /**

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/SwitchNode.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/SwitchNode.java
@@ -43,6 +43,7 @@ public final class SwitchNode extends BreakableStatement {
     private final Expression expression;
 
     /** Switch cases. */
+    @SuppressWarnings("serial")
     private final List<CaseNode> cases;
 
     /** Switch default index. */

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/TemplateLiteral.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/TemplateLiteral.java
@@ -38,6 +38,7 @@ import org.openjdk.nashorn.internal.ir.visitor.NodeVisitor;
  */
 public final class TemplateLiteral extends Expression {
     private static final long serialVersionUID = 1L;
+    @SuppressWarnings("serial")
     private final List<Expression> exprs;
 
     public TemplateLiteral(final List<Expression> exprs) {

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/TryNode.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/ir/TryNode.java
@@ -44,6 +44,7 @@ public final class TryNode extends LexicalContextStatement implements JoinPredec
     private final Block body;
 
     /** List of catch clauses. */
+    @SuppressWarnings("serial")
     private final List<Block> catchBlocks;
 
     /** Finally clause. */
@@ -62,6 +63,7 @@ public final class TryNode extends LexicalContextStatement implements JoinPredec
      * Statement as the type of bodies of e.g. IfNode, WhileNode etc. but rather blockify them even when they're
      * single statements.
      */
+    @SuppressWarnings("serial")
     private final List<Block> inlinedFinallies;
 
     /** Exception symbol. */

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/ArrayBufferView.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/objects/ArrayBufferView.java
@@ -47,6 +47,7 @@ import org.openjdk.nashorn.internal.runtime.arrays.TypedArrayData;
  * ArrayBufferView, es6 class or TypedArray implementation
  */
 @ScriptClass("ArrayBufferView")
+@SuppressWarnings("this-escape")
 public abstract class ArrayBufferView extends ScriptObject {
     private final NativeArrayBuffer buffer;
     private final int byteOffset;

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/parser/Parser.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/parser/Parser.java
@@ -4116,7 +4116,7 @@ public class Parser extends AbstractParser implements Loggable {
         int bodyFinish = 0;
 
         final boolean parseBody;
-        Object endParserState = null;
+        Serializable endParserState = null;
         try {
             // Create a new function block.
             body = newBlock();

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/parser/ParserContextFunctionNode.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/parser/ParserContextFunctionNode.java
@@ -24,6 +24,7 @@
  */
 package org.openjdk.nashorn.internal.parser;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -64,7 +65,7 @@ class ParserContextFunctionNode extends ParserContextBaseNode {
     private long lastToken;
 
     /** Opaque node for parser end state, see {@link Parser} */
-    private Object endParserState;
+    private Serializable endParserState;
 
     private HashSet<String> parameterBoundNames;
     private IdentNode duplicateParameterBinding;
@@ -209,7 +210,7 @@ class ParserContextFunctionNode extends ParserContextBaseNode {
      * Returns the ParserState of when the parsing of this function was ended
      * @return endParserState The end parser state
      */
-    public Object getEndParserState() {
+    public Serializable getEndParserState() {
         return endParserState;
     }
 
@@ -217,7 +218,7 @@ class ParserContextFunctionNode extends ParserContextBaseNode {
      * Sets the ParserState of when the parsing of this function was ended
      * @param endParserState The end parser state
      */
-    public void setEndParserState(final Object endParserState) {
+    public void setEndParserState(final Serializable endParserState) {
         this.endParserState = endParserState;
     }
 

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/AccessorProperty.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/AccessorProperty.java
@@ -50,6 +50,7 @@ import org.openjdk.nashorn.internal.objects.Global;
  * An AccessorProperty is the most generic property type. An AccessorProperty is
  * represented as fields in a ScriptObject class.
  */
+@SuppressWarnings("this-escape")
 public class AccessorProperty extends Property {
     private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
 

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptFunction.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/ScriptFunction.java
@@ -66,6 +66,7 @@ import org.openjdk.nashorn.internal.runtime.logging.DebugLogger;
  * and protected constructors. There are no *public* constructors - but only
  * factory methods that follow the naming pattern "createXYZ".
  */
+@SuppressWarnings("this-escape")
 public class ScriptFunction extends ScriptObject {
 
     /**

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/SpillProperty.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/SpillProperty.java
@@ -33,6 +33,7 @@ import java.lang.invoke.MethodHandles;
 /**
  * Spill property
  */
+@SuppressWarnings("this-escape")
 public class SpillProperty extends AccessorProperty {
     private static final long serialVersionUID = 3028496245198669460L;
 

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/Undefined.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/Undefined.java
@@ -28,6 +28,7 @@ package org.openjdk.nashorn.internal.runtime;
 import static org.openjdk.nashorn.internal.lookup.Lookup.MH;
 import static org.openjdk.nashorn.internal.runtime.ECMAErrors.typeError;
 
+import java.io.Serializable;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import jdk.dynalink.CallSiteDescriptor;
@@ -39,13 +40,17 @@ import org.openjdk.nashorn.internal.runtime.linker.NashornCallSiteDescriptor;
 /**
  * Unique instance of this class is used to represent JavaScript undefined.
  */
-public final class Undefined extends DefaultPropertyAccess {
+public final class Undefined extends DefaultPropertyAccess implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private Undefined() {
+    private final boolean isEmpty;
+
+    private Undefined(boolean isEmpty) {
+        this.isEmpty = isEmpty;
     }
 
-    private static final Undefined UNDEFINED = new Undefined();
-    private static final Undefined EMPTY     = new Undefined();
+    private static final Undefined UNDEFINED = new Undefined(false);
+    private static final Undefined EMPTY     = new Undefined(true);
 
     // Guard used for indexed property access/set on the Undefined instance
     private static final MethodHandle UNDEFINED_GUARD = Guards.getIdentityGuard(UNDEFINED);
@@ -183,5 +188,9 @@ public final class Undefined extends DefaultPropertyAccess {
 
     private static MethodHandle findOwnMH(final String name, final Class<?> rtype, final Class<?>... types) {
         return MH.findVirtual(MethodHandles.lookup(), Undefined.class, name, MH.type(rtype, types));
+    }
+
+    private Object readResolve() {
+        return isEmpty ? EMPTY : UNDEFINED;
     }
 }

--- a/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/doubleconv/Bignum.java
+++ b/src/org.openjdk.nashorn/share/classes/org/openjdk/nashorn/internal/runtime/doubleconv/Bignum.java
@@ -586,7 +586,7 @@ class Bignum {
             assert (bigits_[used_digits_ - 1] < 0x10000);
             // Remove the multiples of the first digit.
             // Example this = 23 and other equals 9. -> Remove 2 multiples.
-            result += (bigits_[used_digits_ - 1]);
+            result += (char) bigits_[used_digits_ - 1];
             subtractTimes(other, bigits_[used_digits_ - 1]);
         }
 
@@ -603,14 +603,14 @@ class Bignum {
             final int quotient = Integer.divideUnsigned(this_bigit, other_bigit);
             bigits_[used_digits_ - 1] = this_bigit - other_bigit * quotient;
             assert (Integer.compareUnsigned(quotient, 0x10000) < 0);
-            result += quotient;
+            result += (char) quotient;
             clamp();
             return result;
         }
 
         final int division_estimate = Integer.divideUnsigned(this_bigit, (other_bigit + 1));
         assert (Integer.compareUnsigned(division_estimate, 0x10000) < 0);
-        result += division_estimate;
+        result += (char) division_estimate;
         subtractTimes(other, division_estimate);
 
         if (other_bigit * (division_estimate + 1) > this_bigit) {


### PR DESCRIPTION
Even though Nashorn targets Java 11 as its minimum version, it needs to be forward compatible with newer versions of Java as well. For this reason, we must ensure it compiles on newer Java versions too. Newer versions of Java do introduce some stricter checks that we address here:
* we had some `lossy-conversions` warnings that got fixed
* There was a lot of `serial` warnings. Even though the value of Nashorn classes being serializable is a bit dubious, for now we'll play along. The strategy for fixing was to either ensure relevant types are serializable, or to add warning suppressions, especially for fields declared as `List` or `Map` in serializable classes; we don't want to narrow those down to `ArrayList` or `HashMap` etc. (which wouldn't trigger the warning.)
* The causes for `this-escape` warnings were reviewed and considered to be okay. I added suppressions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8346848](https://bugs.openjdk.org/browse/JDK-8346848): Eliminate compilation warnings with Java 21 (**Task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/nashorn.git pull/21/head:pull/21` \
`$ git checkout pull/21`

Update a local copy of the PR: \
`$ git checkout pull/21` \
`$ git pull https://git.openjdk.org/nashorn.git pull/21/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21`

View PR using the GUI difftool: \
`$ git pr show -t 21`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/nashorn/pull/21.diff">https://git.openjdk.org/nashorn/pull/21.diff</a>

</details>
