### PR TITLE
docs: Use SPDX license ID

### DIFF
--- a/make/nashorn/nashorn-core.pom
+++ b/make/nashorn/nashorn-core.pom
@@ -37,7 +37,7 @@ questions.
 
   <licenses>
     <license>
-      <name>GPL-2.0-with-classpath-exception</name>
+      <name>GPL-2.0-only WITH Classpath-exception-2.0</name>
       <url>https://github.com/openjdk/nashorn/blob/main/LICENSE</url>
     </license>
   </licenses>

--- a/make/nashorn/nashorn-core.pom
+++ b/make/nashorn/nashorn-core.pom
@@ -37,7 +37,7 @@ questions.
 
   <licenses>
     <license>
-      <name>GPL v2 with the Classpath exception</name>
+      <name>GPL-2.0-with-classpath-exception</name>
       <url>https://github.com/openjdk/nashorn/blob/main/LICENSE</url>
     </license>
   </licenses>

--- a/make/nashorn/nashorn-core.pom
+++ b/make/nashorn/nashorn-core.pom
@@ -37,7 +37,7 @@ questions.
 
   <licenses>
     <license>
-      <name>GPL-2.0-only WITH Classpath-exception-2.0</name>
+      <name>GPL-2.0-with-classpath-exception</name>
       <url>https://github.com/openjdk/nashorn/blob/main/LICENSE</url>
     </license>
   </licenses>


### PR DESCRIPTION
Maven POM should use SPDX license ID: https://maven.apache.org/pom.html#Licenses

SPDX License ID is `GPL-2.0-with-classpath-exception` per https://spdx.org/licenses/GPL-2.0-with-classpath-exception.html

The ID is deprecated, but the replacement is an expression instead of an ID.

Using an expression in place of an ID will result in an invalid CycloneDX BOM, e.g. https://github.com/DependencyTrack/dependency-track/issues/4748

Using correct SPDX license ID allows SCA tools (e.g. https://dependencytrack.org/) to correctly identify the used license.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/nashorn.git pull/27/head:pull/27` \
`$ git checkout pull/27`

Update a local copy of the PR: \
`$ git checkout pull/27` \
`$ git pull https://git.openjdk.org/nashorn.git pull/27/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27`

View PR using the GUI difftool: \
`$ git pr show -t 27`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/nashorn/pull/27.diff">https://git.openjdk.org/nashorn/pull/27.diff</a>

</details>
